### PR TITLE
Improve documentation and refactor FUSB302B driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,201 @@
-# Satellite1-ESPHome (Sendspin Development Fork)
+# Satellite1 ESPHome Firmware - Sendspin Multi-Room Audio
 
-> **This is a development fork** of the original [FutureProofHomes/Satellite1-ESPHome](https://github.com/FutureProofHomes/Satellite1-ESPHome) project.
+**ESPHome firmware for FutureProofHomes Satellite1 with synchronized multi-room audio using Sendspin**
 
-## Status: Work in Progress
+> **Experimental Development Fork** | Based on the original [FutureProofHomes/Satellite1-ESPHome](https://github.com/FutureProofHomes/Satellite1-ESPHome) project
 
-This fork is actively being developed and is **not yet ready for production use**. Expect breaking changes, incomplete features, and experimental code.
-
-> **Snapcast is NOT supported.** This fork uses [Sendspin](https://github.com/esphome/esphome/pull/12284) for multi-room audio instead of Snapcast. If you need Snapcast support, use the official FutureProofHomes firmware.
-
----
-
-## Install Firmware
-
-Install the firmware directly from your browser (Chrome/Edge required):
-
-**[Install Firmware](https://remcom.github.io/Satellite1-ESPHome/site/)**
-
-Available variants:
-
-- **Default** - Base firmware without radar sensor
-- **LD2410** - With HLK-LD2410 presence detection
-- **LD2450** - With HLK-LD2450 zone tracking
+[![ESPHome](https://img.shields.io/badge/ESPHome-2026.1.2-blue)](https://esphome.io)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-Compatible-green)](https://www.home-assistant.io/)
+[![License](https://img.shields.io/badge/License-Same%20as%20upstream-lightgrey)](LICENSE)
 
 ---
 
-## Purpose
+## 🎯 What is This?
 
-The primary goals of this fork are:
+This firmware enables **synchronized multi-room audio** on the [FutureProofHomes Satellite1](https://futureproofhomes.net/) voice assistant hardware using **Sendspin** - a next-generation ESPHome audio synchronization protocol. Perfect for whole-home voice control and perfectly synchronized music playback across multiple rooms.
 
-### 1. Sendspin Support
-Enable [Sendspin](https://github.com/esphome/esphome/pull/12284) synchronized multi-room audio playback on the Satellite1 hardware. Sendspin allows multiple ESPHome devices to play audio in perfect sync across rooms.
+### Key Features
 
-### 2. Upstream ESPHome Integration
-Work towards getting the Satellite1's custom components merged into ESPHome's mainstream codebase.
-
-### 3. Voice PE Feature Parity
-Bring features from [Home Assistant Voice PE](https://github.com/esphome/home-assistant-voice-pe) to the Satellite1.
-
----
-
-## What's Different from Upstream
-
-| Feature          | This Fork    | Official FPH |
-| ---------------- | ------------ | ------------ |
-| Multi-room audio | Sendspin     | Snapcast     |
-| Snapcast support | No           | Yes          |
-| Status           | Experimental | Stable       |
-
-This fork includes experimental features not yet in the main FutureProofHomes repository:
-
-- **Sendspin integration** for multi-room synchronized audio
-- **No Snapcast support** - removed in favor of Sendspin
+✅ **Sendspin Multi-Room Audio** - Play music in perfect sync across multiple Satellite1 devices
+✅ **Home Assistant Voice Assistant** - Full integration with Home Assistant's local voice control
+✅ **ESPHome Dashboard Support** - Easy adoption and automatic updates
+✅ **Presence Detection** - Optional LD2410/LD2450 radar sensor support
+✅ **Power Optimized** - Smart DAC power management for reduced energy consumption
+✅ **Professional Hardware Drivers** - Optimized TAS2780, PCM5122, and FUSB302B drivers
 
 ---
 
-## Requirements
+## ⚠️ Important Notice
 
-- ESPHome **2026.1.1** or newer
-- FutureProofHomes Satellite1 hardware (Core Board + HAT)
-- Home Assistant with Voice Assistant configured
+**This is experimental firmware under active development.**
+
+- ❌ **Not production-ready** - Expect breaking changes and updates
+- ❌ **No Snapcast support** - This fork uses [Sendspin](https://github.com/esphome/esphome/pull/12284) instead
+- ✅ **For Snapcast users** - Please use the official [FutureProofHomes firmware](https://github.com/FutureProofHomes/Satellite1-ESPHome)
 
 ---
 
-## Building from Source
+## 🚀 Quick Install
+
+Install firmware directly from your browser (Chrome/Edge required):
+
+### **[→ Install Firmware Now](https://remcom.github.io/Satellite1-ESPHome/site/)**
+
+**Available Variants:**
+
+| Variant | Best For | Features |
+|---------|----------|----------|
+| **Standard** | Voice assistant + music | Base firmware without radar |
+| **LD2410** | Room presence detection | + HLK-LD2410 presence sensor |
+| **LD2450** | Advanced zone tracking | + HLK-LD2450 multi-zone radar |
+
+---
+
+## 🎵 What Makes This Different?
+
+### Sendspin vs. Snapcast
+
+This firmware uses **Sendspin** for multi-room audio synchronization instead of Snapcast:
+
+- **Native ESPHome integration** - No external servers required
+- **Lower latency** - Optimized for ESP32 hardware
+- **Better Home Assistant integration** - Seamless media player control
+- **Future-proof** - Built for ESPHome's audio pipeline architecture
+
+### Additional Enhancements
+
+Beyond multi-room audio, this fork includes:
+
+- **ESPHome Dashboard adoption** - One-click setup and automatic updates
+- **Hardware diagnostics** - Optional TAS2780 voltage and temperature monitoring
+- **Improved GPIO handling** - Enhanced reliability and null safety
+- **Smart power management** - Automatic DAC shutoff when idle
+- **Optimized memory usage** - Better SPI buffer allocation
+
+---
+
+## 💡 Use Cases
+
+**Perfect for:**
+
+- 🏠 **Whole-home voice control** - Control Home Assistant from any room
+- 🎶 **Multi-room music** - Play synchronized music across your entire home
+- 🛏️ **Presence-based automation** - Trigger actions based on room occupancy (with radar variants)
+- 🔊 **High-quality audio** - Professional DAC and amplifier for excellent sound
+- 🌐 **Local voice assistant** - Privacy-focused, works without cloud services
+
+---
+
+## 📋 System Requirements
+
+### Hardware
+
+- **FutureProofHomes Satellite1** (Core Board + HAT)
+- **Optional:** LD2410 or LD2450 radar sensor for presence detection
+
+### Software
+
+- **ESPHome** 2026.1.2 or newer
+- **Home Assistant** with Voice Assistant configured
+- **Chrome or Edge browser** (for web installer)
+
+### Recommended Setup
+
+- Multiple Satellite1 devices for multi-room audio
+- Stable Wi-Fi network (2.4GHz or 5GHz)
+- Home Assistant OS or Supervised installation
+
+---
+
+## 🛠️ Building from Source
+
+For developers and advanced users who want to customize the firmware:
 
 ```bash
+# Clone the repository
+git clone https://github.com/remcom/Satellite1-ESPHome.git
+cd Satellite1-ESPHome
+
 # Set up the build environment
 source scripts/setup_build_env.sh
 
-# Compile
+# Compile firmware
 esphome compile config/satellite1.yaml
 
 # Upload to device
 esphome upload config/satellite1.yaml
 
-# View logs
+# View live logs
 esphome logs config/satellite1.yaml
 ```
 
-Firmware variants:
+### Firmware Configuration Files
 
-- `config/satellite1.yaml` - Default (no radar)
-- `config/satellite1.ld2410.yaml` - With LD2410 radar
-- `config/satellite1.ld2450.yaml` - With LD2450 radar
-
----
-
-## Contributing
-
-This is an experimental fork. If you're interested in:
-
-- **Stable firmware with Snapcast**: Use the official [FutureProofHomes/Satellite1-ESPHome](https://github.com/FutureProofHomes/Satellite1-ESPHome)
-- **Sendspin testing**: Issues and PRs welcome here
+| File | Purpose |
+| ---- | ------- |
+| `config/satellite1.yaml` | Standard variant (no radar) |
+| `config/satellite1.ld2410.yaml` | LD2410 radar variant |
+| `config/satellite1.ld2450.yaml` | LD2450 radar variant |
+| `config/satellite1.base.yaml` | Base configuration (shared by all variants) |
+| `config/common/*.yaml` | Modular components (voice, media, LEDs, buttons) |
 
 ---
 
-## Credits
+## 🤝 Contributing
 
-- **[FutureProofHomes](https://futureproofhomes.net/)** - Original Satellite1 hardware and firmware
-- **[Nabu Casa](https://nabucasa.com/)** - Home Assistant and ESPHome
-- **ESPHome community** - Sendspin and media player improvements
+We welcome contributions! This is an experimental project exploring new ESPHome audio features.
+
+### How to Help
+
+- 🐛 **Report bugs** - [Open an issue](https://github.com/remcom/Satellite1-ESPHome/issues) if something doesn't work
+- 💡 **Suggest features** - Share ideas for improvements
+- 🧪 **Test and provide feedback** - Try the latest beta releases
+- 📝 **Improve documentation** - Help others get started
+
+### Choosing the Right Firmware
+
+- **Want stable, production-ready firmware?** → Use the official [FutureProofHomes/Satellite1-ESPHome](https://github.com/FutureProofHomes/Satellite1-ESPHome)
+- **Need Snapcast support?** → Use the official FutureProofHomes firmware
+- **Want to test Sendspin?** → You're in the right place!
 
 ---
 
-## License
+## 📚 Documentation & Resources
 
-Same as the original project - see [LICENSE](LICENSE) for details.
+### Project Links
+
+- 🌐 **Web Installer** - [remcom.github.io/Satellite1-ESPHome](https://remcom.github.io/Satellite1-ESPHome/)
+- 📖 **Official FPH Firmware** - [FutureProofHomes/Satellite1-ESPHome](https://github.com/FutureProofHomes/Satellite1-ESPHome)
+- 📘 **FutureProofHomes Docs** - [docs.futureproofhomes.net](https://docs.futureproofhomes.net)
+
+### ESPHome & Home Assistant
+
+- 🏠 **Home Assistant** - [home-assistant.io](https://www.home-assistant.io/)
+- ⚡ **ESPHome** - [esphome.io](https://esphome.io)
+- 🔊 **Sendspin PR** - [esphome/esphome#12284](https://github.com/esphome/esphome/pull/12284)
+- 🎙️ **Voice PE Project** - [home-assistant-voice-pe](https://github.com/esphome/home-assistant-voice-pe)
 
 ---
 
-## Links
+## 🙏 Credits
 
-- **Firmware installer**: [remcom.github.io/Satellite1-ESPHome](https://remcom.github.io/Satellite1-ESPHome/)
-- Official firmware: [FutureProofHomes/Satellite1-ESPHome](https://github.com/FutureProofHomes/Satellite1-ESPHome)
-- FutureProofHomes docs: [docs.futureproofhomes.net](https://docs.futureproofhomes.net)
-- Sendspin PR: [esphome/esphome#12284](https://github.com/esphome/esphome/pull/12284)
-- Home Assistant Voice PE: [esphome/home-assistant-voice-pe](https://github.com/esphome/home-assistant-voice-pe)
-- ESPHome: [esphome.io](https://esphome.io)
+This project builds upon excellent work from:
+
+- **[FutureProofHomes](https://futureproofhomes.net/)** - Satellite1 hardware design and original firmware
+- **[Nabu Casa](https://nabucasa.com/)** - Home Assistant and ESPHome development
+- **ESPHome Community** - Sendspin protocol and media player improvements
+- **Contributors** - Everyone who has tested, reported issues, and contributed code
+
+---
+
+## 📄 License
+
+This project uses the same license as the original FutureProofHomes/Satellite1-ESPHome project.
+
+See [LICENSE](LICENSE) for full details.
+
+---
+
+## 🔍 Keywords
+
+ESPHome firmware, Satellite1, voice assistant, multi-room audio, synchronized audio, Sendspin, Home Assistant, ESP32, local voice control, smart home, whole home audio, presence detection, LD2410, LD2450, TAS2780, PCM5122, FutureProofHomes

--- a/components/fusb302b/fusb302b.h
+++ b/components/fusb302b/fusb302b.h
@@ -26,11 +26,16 @@ typedef union {
 } fusb_status;
 
 class FUSB302B : public PowerDelivery, public Component, protected i2c::I2CDevice {
+  friend void msg_reader_task(void *params);
+  friend void trigger_task(void *params);
+  friend void fusb302b_isr_handler(void *arg);
+
  public:
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void loop() override;
+  void on_shutdown() override;
 
   bool send_message_(const PDMsg &msg) override;
   bool read_message_(PDMsg &msg) override;
@@ -65,8 +70,12 @@ class FUSB302B : public PowerDelivery, public Component, protected i2c::I2CDevic
   }
 
   bool init_fusb_settings_();
+  void cleanup_();
 
   SemaphoreHandle_t i2c_lock_;
+  TaskHandle_t reader_task_handle_{nullptr};
+  TaskHandle_t process_task_handle_{nullptr};
+  QueueHandle_t message_queue_{nullptr};
 };
 
 }  // namespace power_delivery


### PR DESCRIPTION
## Summary

- **README enhancements** - Complete rewrite with improved structure, clearer feature descriptions, installation instructions, and comprehensive documentation for users and developers
- **FUSB302B driver refactoring** - Enhanced thread safety by moving global variables to instance members, added proper resource cleanup with `on_shutdown()`, fixed timer overflow issues, and improved error handling

## Changes

### Documentation
- Restructured README with clear sections for features, installation, use cases, and requirements
- Added badges for ESPHome version and Home Assistant compatibility
- Improved Sendspin vs. Snapcast comparison and multi-room audio explanation
- Enhanced build instructions and firmware variant documentation
- Added contributing guidelines and better resource links

### FUSB302B Component
- Move global static task handles and message queue into `FUSB302B` class instance
- Add `cleanup_()` method and `on_shutdown()` override for proper resource management
- Fix unsigned timer comparison issues (prevent overflow bugs)
- Make message counter atomic for thread safety
- Add error handling for task and queue creation failures
- Pass FUSB302B instance to ISR handler for proper context
- Remove commented-out dead code and debug statements
- Refactor `PDMsg` constructors to take `PowerDelivery` pointer for accessing instance-specific state