### PR TITLE
update to ESPHome 2026.2.0 and minor config fixes

### DIFF
--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -18,9 +18,11 @@ audio_dac:
     pvdd_sensor:
       name: "Amplifier Supply Voltage"
       disabled_by_default: true
+      entity_category: diagnostic
     temperature_sensor:
       name: "Amplifier Temperature"
       disabled_by_default: true
+      entity_category: diagnostic
 
   - platform: pcm5122
     id: speaker_dac_pcm5122
@@ -378,6 +380,6 @@ interval:
                     - media_player.is_idle: external_media_player
                     - media_player.is_paused: external_media_player
           then:
-            - logger.log: "Deactivating TAS2780 due to 10 minutes of idle"
+            - logger.log: "Deactivating TAS2780 due to 60 seconds of idle"
             - tas2780.deactivate:
             - lambda: id(tas2780_active) = false;

--- a/config/satellite1.ld2450.yaml
+++ b/config/satellite1.ld2450.yaml
@@ -33,5 +33,5 @@ switch:
       - component.update: update_http_request
     on_turn_off:
       - logger.log: "OTA updates set to use Production firmware"
-      - lambda: id(update_http_request).set_source_url("https://github.com/remcom/Satellite1-ESPHome/releases/download/latest/satellite1-manifest.json");
+      - lambda: id(update_http_request).set_source_url("https://github.com/remcom/Satellite1-ESPHome/releases/download/latest/satellite1.ld2450-manifest.json");
       - component.update: update_http_request

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -95,12 +95,6 @@ external_components:
       - dac_switcher
   # ESPHome PRs for sendspin and related features
   - source:
-      # https://github.com/esphome/esphome/pull/12253 (merged into upstream ESPHome, will be available in ESPHome 2026.2.0)
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: c28c97fbaf15c4ce353317e873054fb00a1d7a6d  # ESPHome dev branch commit hash
-    components: [mixer]
-  - source:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2026.1.5
+esphome==2026.2.0
 setuptools


### PR DESCRIPTION
## Summary

- Bumps ESPHome from `2026.1.5` to `2026.2.0`
- Removes the external `mixer` component — it has been merged upstream and is now included in ESPHome 2026.2.0 (PR #12253)
- Fixes the LD2450 OTA manifest URL, which was incorrectly pointing to the base `satellite1-manifest.json` instead of `satellite1.ld2450-manifest.json`
- Marks amplifier supply voltage and temperature sensors as `diagnostic` entities
- Fixes a stale log message in the TAS2780 idle deactivation interval (said "10 minutes", actual timeout is 60 seconds)