### PR TITLE
bump esphome to 2026.2.0

### DIFF
--- a/config/common/timer.yaml
+++ b/config/common/timer.yaml
@@ -74,8 +74,6 @@ script:
           for (const auto &timer : timers) {
             if (timer.is_active) {
               output = true;
-
-
             }
           }
           id(is_timer_active) = output;

--- a/config/common/timer.yaml
+++ b/config/common/timer.yaml
@@ -56,11 +56,11 @@ script:
   - id: fetch_first_active_timer
     then:
       - lambda: |
-          const auto timers = id(va).get_timers();
-          auto output_timer = timers.begin()->second;
-          for (auto &iterable_timer : timers) {
-            if (iterable_timer.second.is_active && iterable_timer.second.seconds_left <= output_timer.seconds_left) {
-              output_timer = iterable_timer.second;
+          const auto &timers = id(va).get_timers();
+          auto output_timer = *timers.begin();
+          for (const auto &timer : timers) {
+            if (timer.is_active && timer.seconds_left <= output_timer.seconds_left) {
+              output_timer = timer;
             }
           }
           id(first_active_timer) = output_timer;
@@ -69,13 +69,13 @@ script:
   - id: check_if_timers_active
     then:
       - lambda: |
-          const auto timers = id(va).get_timers();
+          const auto &timers = id(va).get_timers();
           bool output = false;
-          if (timers.size() > 0) {
-            for (auto &iterable_timer : timers) {
-              if(iterable_timer.second.is_active) {
-                output = true;
-              }
+          for (const auto &timer : timers) {
+            if (timer.is_active) {
+              output = true;
+
+
             }
           }
           id(is_timer_active) = output;

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -36,7 +36,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2026.1.5
+  min_version: 2026.2.0
 
   project:
     name: ${company_name}.${project_name}

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -95,34 +95,34 @@ external_components:
       - dac_switcher
   # ESPHome PRs for sendspin and related features
   - source:
-      # https://github.com/esphome/esphome/pull/12253 (merged into upstream ESPHome, will be available in ESPHome 2026.2.0)
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: c28c97fbaf15c4ce353317e873054fb00a1d7a6d  # ESPHome dev branch commit hash
-    components: [mixer]  
-  - source:
       # https://github.com/esphome/esphome/pull/12256
       type: git
       url: https://github.com/esphome/esphome
-      ref: 9148832ea4e54907bad71a24d4ced1ce6c862433
+      ref: a2d98e1d5e020200db8f3caf27a74a939a661dc4
     components: [audio]
   - source:
       # https://github.com/esphome/esphome/pull/12258
       type: git
       url: https://github.com/esphome/esphome
-      ref: bff22983a390352360796f8e1363127e0cd1f898
+      ref: b4b7c5b25ebe0f2ab988f700219fa3c57b2377b7
     components: [media_player]
   - source:
       # https://github.com/esphome/esphome/pull/12284
       type: git
       url: https://github.com/esphome/esphome
-      ref: 3cc894763b05ac8ffd9fdd15bcb549d47cadf6eb
-    components: [mdns, sendspin]
+      ref: d48058e140c98f5c2d902661d851a6b712d62434
+    components: [sendspin]
+  - source:
+      # https://github.com/esphome/esphome/pull/14013
+      type: git
+      url: https://github.com/esphome/esphome
+      ref: 51dcce3d1f22865ebb458a5447bbc877ac946b5a
+    components: [mdns]
   - source:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: 32708a2ee74f5ea4107448f62755004ad3e879c5
+      ref: b49b09b6ae56502aa3ce51be86f90d732d019b2c
     components: [file, http_request, media_source, speaker_source]
 
 logger:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2026.1.5
+esphome==2026.2.0
 setuptools


### PR DESCRIPTION
## Bump ESPHome to 2026.2.0

## Summary
- Upgrades ESPHome from `2026.1.5` to `2026.2.0` in `requirements.txt` and `min_version`
- Removes the external `mixer` component (now merged into ESPHome upstream and available in 2026.2.0)
- Updates commit refs for all remaining external components (`audio`, `media_player`, `sendspin`, `file`/`http_request`/`media_source`/`speaker_source`)
- Fixes timer lambda code in `timer.yaml` to use updated `get_timers()` API: timers are now returned as a flat range instead of a map, removing `.second` accessor