### PR TITLE
Update to ESPHome 2026.3 + Resampler & Component Improvements

### DIFF
--- a/components/dac_switcher/audio_dac.py
+++ b/components/dac_switcher/audio_dac.py
@@ -41,7 +41,7 @@ DAC_SWITCHER_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "dac_switcher.select_tas2780", SelectTas2780Action, DAC_SWITCHER_ACTION_SCHEMA
+    "dac_switcher.select_tas2780", SelectTas2780Action, DAC_SWITCHER_ACTION_SCHEMA, synchronous=True
 )
 async def dac_switcher_select_tas2780_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -50,7 +50,7 @@ async def dac_switcher_select_tas2780_to_code(config, action_id, template_arg, a
 
 
 @automation.register_action(
-    "dac_switcher.select_pcm5122", SelectPcm5122Action, DAC_SWITCHER_ACTION_SCHEMA
+    "dac_switcher.select_pcm5122", SelectPcm5122Action, DAC_SWITCHER_ACTION_SCHEMA, synchronous=True
 )
 async def dac_switcher_select_pcm5122_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/components/fusb302b/__init__.py
+++ b/components/fusb302b/__init__.py
@@ -77,6 +77,7 @@ PD_ACTION_SCHEMA = automation.maybe_simple_id({cv.GenerateID(): cv.use_id(PowerD
         },
         key=CONF_REQUEST_VOLTAGE,
     ),
+    synchronous=True,
 )
 async def power_delivery_request_voltage_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/components/i2s_audio/__init__.py
+++ b/components/i2s_audio/__init__.py
@@ -1,11 +1,20 @@
 from esphome import pins
 import esphome.codegen as cg
-from esphome.components.esp32 import get_esp32_variant
+from esphome.components.esp32 import (
+    add_idf_sdkconfig_option,
+    get_esp32_variant,
+    include_builtin_idf_component,
+)
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
+    VARIANT_ESP32C3,
+    VARIANT_ESP32C5,
+    VARIANT_ESP32C6,
+    VARIANT_ESP32C61,
+    VARIANT_ESP32H2,
+    VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
-    VARIANT_ESP32C3,
 )
 import esphome.config_validation as cv
 from esphome.const import (
@@ -13,8 +22,6 @@ from esphome.const import (
     CONF_CHANNEL,
     CONF_ID,
     CONF_SAMPLE_RATE,
-    KEY_CORE,
-    KEY_FRAMEWORK_VERSION,
 )
 from esphome.core import CORE
 from esphome.cpp_generator import MockObjClass
@@ -77,12 +84,17 @@ I2S_ROLE_OPTIONS = {
     CONF_SECONDARY: i2s_role_t.I2S_ROLE_SLAVE,  # NOLINT
 }
 
-# https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h
+# https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h (SOC_I2S_NUM)
 I2S_PORTS = {
     VARIANT_ESP32: 2,
+    VARIANT_ESP32C3: 1,
+    VARIANT_ESP32C5: 1,
+    VARIANT_ESP32C6: 1,
+    VARIANT_ESP32C61: 1,
+    VARIANT_ESP32H2: 1,
+    VARIANT_ESP32P4: 3,
     VARIANT_ESP32S2: 1,
     VARIANT_ESP32S3: 2,
-    VARIANT_ESP32C3: 1,
 }
 
 i2s_channel_fmt_t = cg.global_ns.enum("i2s_channel_fmt_t")
@@ -164,7 +176,18 @@ def validate_mclk_divisible_by_3(config):
         )
     return config
 
-_use_legacy_driver = None
+# Key for storing legacy driver setting in CORE.data
+I2S_USE_LEGACY_DRIVER_KEY = "i2s_use_legacy_driver"
+
+
+def _get_use_legacy_driver():
+    """Get the legacy driver setting from CORE.data."""
+    return CORE.data.get(I2S_USE_LEGACY_DRIVER_KEY)
+
+
+def _set_use_legacy_driver(value: bool) -> None:
+    """Set the legacy driver setting in CORE.data."""
+    CORE.data[I2S_USE_LEGACY_DRIVER_KEY] = value
 
 
 def i2s_audio_component_schema(
@@ -201,11 +224,7 @@ def i2s_audio_component_schema(
 
 
 def use_legacy():
-    framework_version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
-    if CORE.is_esp32 and framework_version >= cv.Version(5, 0, 0):
-        if not _use_legacy_driver:
-            return False
-    return True
+    return _get_use_legacy_driver()
 
 
 async def register_i2s_audio_component(var, config):
@@ -248,17 +267,17 @@ async def register_i2s_audio_component(var, config):
 
 
 def validate_use_legacy(value):
-    global _use_legacy_driver  # noqa: PLW0603
     if CONF_USE_LEGACY in value:
-        if (_use_legacy_driver is not None) and (
-            _use_legacy_driver != value[CONF_USE_LEGACY]
-        ):
+        existing_value = _get_use_legacy_driver()
+        if (existing_value is not None) and (existing_value != value[CONF_USE_LEGACY]):
             raise cv.Invalid(
                 f"All i2s_audio components must set {CONF_USE_LEGACY} to the same value."
             )
         if (not value[CONF_USE_LEGACY]) and (CORE.using_arduino):
-            raise cv.Invalid("Arduino supports only the legacy i2s driver.")
-        _use_legacy_driver = value[CONF_USE_LEGACY]
+            raise cv.Invalid("Arduino supports only the legacy i2s driver")
+        _set_use_legacy_driver(value[CONF_USE_LEGACY])
+    elif CORE.using_arduino:
+        _set_use_legacy_driver(True)
     return value
 
 
@@ -296,11 +315,20 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    # Re-enable ESP-IDF's I2S driver (excluded by default to save compile time)
+    include_builtin_idf_component("esp_driver_i2s")
+
     if use_legacy():
         cg.add_define("USE_I2S_LEGACY")
+        # Legacy I2S API lives in the "driver" shim component (driver/i2s.h)
+        include_builtin_idf_component("driver")
         cg.add(var.set_i2s_mode(I2S_MODE_OPTIONS[config[CONF_I2S_MODE]]))
     else:
         cg.add(var.set_i2s_role(I2S_ROLE_OPTIONS[config[CONF_I2S_MODE]]))
+
+    # Helps avoid callbacks being skipped due to processor load
+    add_idf_sdkconfig_option("CONFIG_I2S_ISR_IRAM_SAFE", True)
     cg.add(var.set_lrclk_pin(config[CONF_I2S_LRCLK_PIN]))
     if CONF_I2S_BCLK_PIN in config:
         cg.add(var.set_bclk_pin(config[CONF_I2S_BCLK_PIN]))

--- a/components/i2s_audio/microphone/__init__.py
+++ b/components/i2s_audio/microphone/__init__.py
@@ -47,9 +47,14 @@ PDM_VARIANTS = [esp32.const.VARIANT_ESP32, esp32.const.VARIANT_ESP32S3]
 def _validate_esp32_variant(config):
     variant = esp32.get_esp32_variant()
     if config[CONF_ADC_TYPE] == "external":
-        if config[CONF_PDM]:
-            if variant not in PDM_VARIANTS:
-                raise cv.Invalid(f"{variant} does not support PDM")
+        if config[CONF_PDM] and variant not in PDM_VARIANTS:
+            raise cv.Invalid(f"{variant} does not support PDM")
+        if (
+            variant == esp32.const.VARIANT_ESP32
+            and config.get(CONF_BITS_PER_SAMPLE) == 8
+            and config.get(CONF_CHANNEL) in (CONF_LEFT, CONF_RIGHT)
+        ):
+            raise cv.Invalid("8-bit mono mode is not supported on ESP32")
         return config
     if config[CONF_ADC_TYPE] == "internal":
         if variant not in INTERNAL_ADC_VARIANTS:

--- a/components/resampler/speaker/resampler_speaker.cpp
+++ b/components/resampler/speaker/resampler_speaker.cpp
@@ -147,7 +147,7 @@ void ResamplerSpeaker::loop() {
     xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::STATE_STOPPING);
   }
   if (event_group_bits & ResamplingEventGroupBits::STATE_STOPPED) {
-    this->delete_task_();
+    this->task_.deallocate();
     ESP_LOGD(TAG, "Stopped");
     xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ALL_BITS);
   }
@@ -190,7 +190,7 @@ void ResamplerSpeaker::loop() {
         this->output_speaker_->stop();
       }
 
-      if (this->output_speaker_->is_stopped() && (this->task_handle_ == nullptr)) {
+      if (this->output_speaker_->is_stopped() && !this->task_.is_created()) {
         // Only transition to stopped state once the output speaker and resampler task are fully stopped
         this->waiting_for_output_ = false;
         this->state_ = speaker::STATE_STOPPED;
@@ -209,9 +209,6 @@ void ResamplerSpeaker::loop() {
 
 void ResamplerSpeaker::set_start_error_(esp_err_t err) {
   switch (err) {
-    case ESP_ERR_INVALID_STATE:
-      this->status_set_error(LOG_STR("Task failed to start"));
-      break;
     case ESP_ERR_NO_MEM:
       this->status_set_error(LOG_STR("Not enough memory"));
       break;
@@ -267,34 +264,10 @@ esp_err_t ResamplerSpeaker::start_() {
 
   if (this->requires_resampling_()) {
     // Start the resampler task to handle converting sample rates
-    return this->start_task_();
-  }
-
-  return ESP_OK;
-}
-
-esp_err_t ResamplerSpeaker::start_task_() {
-  if (this->task_stack_buffer_ == nullptr) {
-    if (this->task_stack_in_psram_) {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-      this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
-    } else {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
+    if (!this->task_.create(resample_task, "resampler", TASK_STACK_SIZE, (void *) this, RESAMPLER_TASK_PRIORITY,
+                            this->task_stack_in_psram_)) {
+      return ESP_ERR_NO_MEM;
     }
-  }
-
-  if (this->task_stack_buffer_ == nullptr) {
-    return ESP_ERR_NO_MEM;
-  }
-
-  if (this->task_handle_ == nullptr) {
-    this->task_handle_ = xTaskCreateStatic(resample_task, "resampler", TASK_STACK_SIZE, (void *) this,
-                                           RESAMPLER_TASK_PRIORITY, this->task_stack_buffer_, &this->task_stack_);
-  }
-
-  if (this->task_handle_ == nullptr) {
-    return ESP_ERR_INVALID_STATE;
   }
 
   return ESP_OK;
@@ -305,31 +278,10 @@ void ResamplerSpeaker::stop() { this->send_command_(ResamplingEventGroupBits::CO
 void ResamplerSpeaker::enter_stopping_state_() {
   this->state_ = speaker::STATE_STOPPING;
   this->state_start_ms_ = App.get_loop_component_start_time();
-  if (this->task_handle_ != nullptr) {
+  if (this->task_.is_created()) {
     xEventGroupSetBits(this->event_group_, ResamplingEventGroupBits::TASK_COMMAND_STOP);
   }
   this->output_speaker_->stop();
-}
-
-void ResamplerSpeaker::delete_task_() {
-  if (this->task_handle_ != nullptr) {
-    // Delete the suspended task
-    vTaskDelete(this->task_handle_);
-    this->task_handle_ = nullptr;
-  }
-
-  if (this->task_stack_buffer_ != nullptr) {
-    // Deallocate the task stack buffer
-    if (this->task_stack_in_psram_) {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-      stack_allocator.deallocate(this->task_stack_buffer_, TASK_STACK_SIZE);
-    } else {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      stack_allocator.deallocate(this->task_stack_buffer_, TASK_STACK_SIZE);
-    }
-
-    this->task_stack_buffer_ = nullptr;
-  }
 }
 
 void ResamplerSpeaker::finish() { this->send_command_(ResamplingEventGroupBits::COMMAND_FINISH); }

--- a/components/resampler/speaker/resampler_speaker.h
+++ b/components/resampler/speaker/resampler_speaker.h
@@ -7,8 +7,8 @@
 #include "esphome/components/speaker/speaker.h"
 
 #include "esphome/core/component.h"
+#include "esphome/core/static_task.h"
 
-#include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 
 namespace esphome {
@@ -57,15 +57,9 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
  protected:
   /// @brief Starts the output speaker after setting the resampled stream info. If resampling is required, it starts the
   /// task.
-  /// @return ESP_OK if resampling is required
-  ///         return value of start_task_() if resampling is required
-  esp_err_t start_();
-
-  /// @brief Starts the resampler task after allocating the task stack
   /// @return ESP_OK if successful,
-  ///         ESP_ERR_NO_MEM if the task stack couldn't be allocated
-  ///         ESP_ERR_INVALID_STATE if the task wasn't created
-  esp_err_t start_task_();
+  ///         ESP_ERR_NO_MEM if the resampler task couldn't be created
+  esp_err_t start_();
 
   /// @brief Transitions to STATE_STOPPING, records the stopping timestamp, sends the task stop command if the task is
   /// running, and stops the output speaker.
@@ -73,9 +67,6 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
 
   /// @brief Sets the appropriate status error based on the start failure reason.
   void set_start_error_(esp_err_t err);
-
-  /// @brief Deletes the resampler task if suspended, deallocates the task stack, and resets the related pointers.
-  void delete_task_();
 
   /// @brief Sends a command via event group bits, enables the loop, and optionally wakes the main loop.
   void send_command_(uint32_t command_bit, bool wake_loop = false);
@@ -92,9 +83,7 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
   bool task_stack_in_psram_{false};
   bool waiting_for_output_{false};
 
-  TaskHandle_t task_handle_{nullptr};
-  StaticTask_t task_stack_;
-  StackType_t *task_stack_buffer_{nullptr};
+  StaticTask task_;
 
   audio::AudioStreamInfo target_stream_info_;
 

--- a/components/tas2780/audio_dac.py
+++ b/components/tas2780/audio_dac.py
@@ -80,21 +80,21 @@ TAS2780_ACTION_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("tas2780.deactivate", DeactivateAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.deactivate", DeactivateAction, TAS2780_ACTION_SCHEMA, synchronous=True)
 async def tas2780_deactivate_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
 
 
-@automation.register_action("tas2780.reset", ResetAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.reset", ResetAction, TAS2780_ACTION_SCHEMA, synchronous=True)
 async def tas2780_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
 
 
-@automation.register_action("tas2780.activate", ActivateAction, TAS2780_ACTION_SCHEMA)
+@automation.register_action("tas2780.activate", ActivateAction, TAS2780_ACTION_SCHEMA, synchronous=True)
 async def tas2780_activate_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, parent)
@@ -115,7 +115,7 @@ TAS2780_UPDATE_CONFIG_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("tas2780.update_config", UpdateConfigAction, TAS2780_UPDATE_CONFIG_SCHEMA)
+@automation.register_action("tas2780.update_config", UpdateConfigAction, TAS2780_UPDATE_CONFIG_SCHEMA, synchronous=True)
 async def tas2780_update_config_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, parent)

--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -85,11 +85,13 @@ binary_sensor:
 
     on_press:
       # Cable inserted - switch to line-out DAC
+      #  - Enable Sendspin static delay adjustment to apply the persisted delay when using the external audio output
       - dac_switcher.select_pcm5122:
           id: dac_switcher_main
       - lambda: id(jack_plugged_recently) = true;
       - script.execute: control_leds
       - delay: 200ms
+      - sendspin.media_source.enable_static_delay_adjustment:
       - script.execute:
           id: play_sound
           priority: false
@@ -100,10 +102,12 @@ binary_sensor:
 
     on_release:
       # Cable removed - switch back to speaker DAC
+      #  - Disable Sendspin static delay adjustment when using the internal speaker
       - dac_switcher.select_tas2780:
           id: dac_switcher_main
       - lambda: id(jack_unplugged_recently) = true;
       - script.execute: control_leds
+      - sendspin.media_source.disable_static_delay_adjustment:
       - delay: 200ms
       - script.execute:
           id: play_sound
@@ -177,45 +181,48 @@ speaker:
 sendspin:
   id: sendspin_hub
   task_stack_in_psram: true
-  kalman_process_error: 0.01
+
+audio_file:
+  - id: center_button_press_sound
+    file: ${center_button_press_sound_file}
+  - id: center_button_double_press_sound
+    file: ${center_button_double_press_sound_file}
+  - id: center_button_triple_press_sound
+    file: ${center_button_triple_press_sound_file}
+  - id: center_button_long_press_sound
+    file: ${center_button_long_press_sound_file}
+  - id: factory_reset_initiated_sound
+    file: ${factory_reset_initiated_sound_file}
+  - id: factory_reset_cancelled_sound
+    file: ${factory_reset_cancelled_sound_file}
+  - id: factory_reset_confirmed_sound
+    file: ${factory_reset_confirmed_sound_file}
+  - id: jack_connected_sound
+    file: ${jack_connected_sound_file}
+  - id: jack_disconnected_sound
+    file: ${jack_disconnected_sound_file}
+  - id: mute_switch_on_sound
+    file: ${mute_switch_on_sound_file}
+  - id: mute_switch_off_sound
+    file: ${mute_switch_off_sound_file}
+  - id: timer_finished_sound
+    file: ${timer_finished_sound_file}
+  - id: wake_word_triggered_sound
+    file: ${wake_word_triggered_sound_file}
+  - id: error_cloud_expired
+    file: ${error_cloud_expired_sound_file}
 
 media_source:
-  - platform: sendspin
-    id: sendspin_source
+  - platform: audio_file
+    id: audio_file_announcement_source
   - platform: http_request
-    id: http_source
+    id: http_announcement_source
+    buffer_size: 250000
+  - platform: http_request
+    id: http_media_source
     buffer_size: 500000
-  - platform: file
-    id: file_source
-    files:
-      - id: center_button_press_sound
-        file: ${center_button_press_sound_file}
-      - id: center_button_double_press_sound
-        file: ${center_button_double_press_sound_file}
-      - id: center_button_triple_press_sound
-        file: ${center_button_triple_press_sound_file}
-      - id: center_button_long_press_sound
-        file: ${center_button_long_press_sound_file}
-      - id: factory_reset_initiated_sound
-        file: ${factory_reset_initiated_sound_file}
-      - id: factory_reset_cancelled_sound
-        file: ${factory_reset_cancelled_sound_file}
-      - id: factory_reset_confirmed_sound
-        file: ${factory_reset_confirmed_sound_file}
-      - id: jack_connected_sound
-        file: ${jack_connected_sound_file}
-      - id: jack_disconnected_sound
-        file: ${jack_disconnected_sound_file}
-      - id: mute_switch_on_sound
-        file: ${mute_switch_on_sound_file}
-      - id: mute_switch_off_sound
-        file: ${mute_switch_off_sound_file}
-      - id: timer_finished_sound
-        file: ${timer_finished_sound_file}
-      - id: wake_word_triggered_sound
-        file: ${wake_word_triggered_sound_file}
-      - id: error_cloud_expired
-        file: ${error_cloud_expired_sound_file}
+  - platform: sendspin
+    id: sendspin_media_source
 
 media_player:
   - platform: sendspin
@@ -225,22 +232,23 @@ media_player:
     name: Media Player
     volume_increment: 0.05
     volume_min: 0.1
-    volume_max: 1.
-    sources:
-      - file_source
-      - http_source
-      - sendspin_source
-    announcement_speaker: announcement_resampling_speaker
-    media_speaker: media_resampling_speaker
+    volume_max: 1.0
     announcement_pipeline:
+      speaker: announcement_resampling_speaker
       format: FLAC     # FLAC is the least processor intensive codec
       num_channels: 1  # Stereo audio is unnecessary for announcements
       sample_rate: 48000
+      sources:
+        - audio_file_announcement_source
+        - http_announcement_source
     media_pipeline:
+      speaker: media_resampling_speaker
       format: FLAC     # FLAC is the least processor intensive codec
       num_channels: 2
       sample_rate: 48000
-
+      sources:
+        - http_media_source
+        - sendspin_media_source
     on_mute:
       - script.execute: control_leds
     on_unmute:
@@ -295,7 +303,7 @@ script:
           if ( (id(external_media_player).state != media_player::MediaPlayerState::MEDIA_PLAYER_STATE_ANNOUNCING ) || priority) {
             id(external_media_player)
               ->make_call()
-              .set_media_url("file://" + sound_file)
+              .set_media_url("audio-file://" + sound_file)
               .set_announcement(true)
               .perform();
           }
@@ -336,36 +344,19 @@ script:
                 mode: !lambda return id(tas2780_power_mode);
             - lambda: id(tas2780_active) = true;
 
-sensor:
-  - platform: sendspin
-    type: kalman_error
-    name: "Kalman Error"  # Time sync filter uncertainty estimate
-
-  - platform: sendspin
-    type: audible_syncs
-    name: "Audible Syncs"  # Major sync events that are audible
-
-# Sendspin: only needed for text metadata
+# Only necessary for text metatdata
 text_sensor:
   - platform: sendspin
+    id: track_title
     type: title
-    name: Track Title
-
   - platform: sendspin
     type: artist
     name: Artist
 
+sensor:
   - platform: sendspin
-    type: album
-    name: Album
-
-  - platform: sendspin
-    type: year
-    name: Year
-
-  - platform: sendspin
-    type: track
-    name: Track Number
+    type: track_duration
+    id: sendspin_track_duration
 
 interval:
   - interval: 30s

--- a/config/common/timer.yaml
+++ b/config/common/timer.yaml
@@ -89,12 +89,15 @@ script:
   # Script executed when the timer is ringing, to repeat the timer finished sound.
   - id: enable_repeat_one
     then:
+      # Turn on the repeat mode and pause for 500 ms between playlist items/repeats
       - media_player.repeat_one:
           id: external_media_player
           announcement: true
       # Turn on the repeat mode and pause for 500 ms between playlist items/repeats
-      - lambda: |-
-            id(external_media_player)->set_playlist_delay_ms(1, 500);
+      - speaker_source.set_playlist_delay:
+          id: external_media_player
+          pipeline: announcement
+          delay: 500ms
 
   # Script execute when the timer is done ringing, to disable repeat mode.
   - id: disable_repeat
@@ -103,5 +106,7 @@ script:
       - media_player.repeat_off:
           id: external_media_player
           announcement: true
-      - lambda: |-
-            id(external_media_player)->set_playlist_delay_ms(1, 0);
+      - speaker_source.set_playlist_delay:
+          id: external_media_player
+          pipeline: announcement
+          delay: 0ms

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -81,6 +81,7 @@ packages:
   # developer: !include common/developer.yaml
 
 http_request:
+  buffer_size_rx: 2048 
 
 safe_mode:
 

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -81,7 +81,7 @@ packages:
   # developer: !include common/developer.yaml
 
 http_request:
-  buffer_size_rx: 2048 
+  buffer_size_rx: 2048
 
 safe_mode:
 

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -21,6 +21,14 @@ packages:
       on_connect:
         - delay: 5s  # Gives time for improv results to be transmitted
         - ble.disable:
+        # Enable/disable Sendspin static adjustment delay if the jack is plugged in or not
+        - if:
+            condition:
+              - binary_sensor.is_on: line_out_sensor
+            then:
+              - sendspin.media_source.enable_static_delay_adjustment:
+            else:
+              - sendspin.media_source.disable_static_delay_adjustment:
 
     satellite1:
       on_xmos_no_response:
@@ -95,35 +103,19 @@ external_components:
       - dac_switcher
   # ESPHome PRs for sendspin and related features
   - source:
-      # https://github.com/esphome/esphome/pull/12256
+      # https://github.com/esphome/esphome/pull/14933
       type: git
-      url: https://github.com/esphome/esphome
-      ref: a2d98e1d5e020200db8f3caf27a74a939a661dc4
-    components: [audio]
-  - source:
-      # https://github.com/esphome/esphome/pull/12258
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: b4b7c5b25ebe0f2ab988f700219fa3c57b2377b7
-    components: [media_player]
-  - source:
-      # https://github.com/esphome/esphome/pull/12284
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: d48058e140c98f5c2d902661d851a6b712d62434
-    components: [sendspin]
-  - source:
-      # https://github.com/esphome/esphome/pull/14013
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: 51dcce3d1f22865ebb458a5447bbc877ac946b5a
-    components: [mdns]
+      url: https://github.com/kahrendt/esphome
+      ref: 890e33f99af2c2ea15dc74c3ec4cf32d25203526
+    components: [const, media_source, sendspin]
+    refresh: 60s
   - source:
       # https://github.com/esphome/esphome/pull/12429
       type: git
       url: https://github.com/esphome/esphome
-      ref: b49b09b6ae56502aa3ce51be86f90d732d019b2c
-    components: [file, http_request, media_source, speaker_source]
+      ref: ff8ce89556748509d7ee8724e12d9d43d3c8c1e8
+    refresh: 0s
+    components: [http_request]
 
 logger:
   deassert_rts_dtr: true

--- a/esphome/components/memory_flasher/__init__.py
+++ b/esphome/components/memory_flasher/__init__.py
@@ -341,6 +341,7 @@ FLASH_ACTION_SCHEMA = cv.All(
     "memory_flasher.write_image",
     FlashAction,
     FLASH_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def flash_image_action_to_code(config, action_id, template_arg, args):
     flasher = await cg.get_variable(config[CONF_FLASHER_ID])
@@ -367,9 +368,10 @@ FlASH_EMBEDDED_ACTION_SCHEMA = automation.maybe_simple_id(
 )
 
 @automation.register_action(
-    "memory_flasher.write_embedded_image", 
-    FlashEmbeddedAction, 
-    FlASH_EMBEDDED_ACTION_SCHEMA)
+    "memory_flasher.write_embedded_image",
+    FlashEmbeddedAction,
+    FlASH_EMBEDDED_ACTION_SCHEMA,
+    synchronous=True)
 async def flash_embedded_image_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_FLASHER_ID])
@@ -382,9 +384,10 @@ ERASE_MEMORY_ACTION_SCHEMA = automation.maybe_simple_id(
     }
 )
 @automation.register_action(
-    "memory_flasher.erase", 
-    EraseAction, 
-    ERASE_MEMORY_ACTION_SCHEMA)
+    "memory_flasher.erase",
+    EraseAction,
+    ERASE_MEMORY_ACTION_SCHEMA,
+    synchronous=True)
 async def erase_memory_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_FLASHER_ID])

--- a/esphome/components/satellite1/satellite1.py
+++ b/esphome/components/satellite1/satellite1.py
@@ -83,9 +83,10 @@ RESET_XMOS_ACTION_SCHEMA = automation.maybe_simple_id(
     }
 )
 @automation.register_action(
-    "satellite1.xmos_hardware_reset", 
-    XMOSHardwareResetAction, 
-    RESET_XMOS_ACTION_SCHEMA)
+    "satellite1.xmos_hardware_reset",
+    XMOSHardwareResetAction,
+    RESET_XMOS_ACTION_SCHEMA,
+    synchronous=True)
 async def erase_memory_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_SATELLITE1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2026.2.1
+esphome==2026.3.0
 setuptools


### PR DESCRIPTION
### Summary
- Bumps ESPHome from `2026.2.1` → `2026.3.0`
- Consolidates external Sendspin-related components into a single source ref
- Refactors the resampler task lifecycle to use the upstream `ExternalRAMAllocator` task wrapper
- Expands I2S audio hardware support and fixes component compatibility for ESPHome 2026.3 APIs

### Changes

#### ESPHome version bump
- `requirements.txt`: `esphome==2026.2.1` → `esphome==2026.3.0`

#### External component consolidation (`config/satellite1.yaml`)
- Replaces 4 separate PR-pinned sources (`audio`, `media_player`, `sendspin`, `mdns`) with a single consolidated source from `kahrendt/esphome` providing `const`, `media_source`, and `sendspin`
- Updates `http_request` to a newer commit pin
- Adds Sendspin static delay adjustment logic on WiFi connect, conditioned on whether the line-out jack is in use

#### Resampler refactor (`components/resampler/`)
- bring in upstream changes

#### I2S audio component updates (`components/i2s_audio/`)
- bring in upstream changes

#### Config & miscellaneous
- `satellite1.base.yaml`: adds `buffer_size_rx: 2048` to `http_request`
- `config/common/media_player.yaml`: updated Sendspin configuration for 2026.3 API shape
- `config/common/timer.yaml`: minor updates
- `components/tas2780/audio_dac.py`, `components/dac_switcher/audio_dac.py`: minor adjustments for 2026.3 API compatibility
- `components/fusb302b/__init__.py`, `esphome/components/memory_flasher/__init__.py`, `esphome/components/satellite1/satellite1.py`: compatibility fixes