### PR TITLE
[pcm5122] Prepare component for upstream ESPHome submission

### DIFF
--- a/components/pcm5122/audio_dac.py
+++ b/components/pcm5122/audio_dac.py
@@ -1,15 +1,14 @@
 import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
-from esphome import automation
-from esphome.components.audio_dac import AudioDac, audio_dac_ns
-from esphome.const import ( 
-    CONF_ID, 
-    CONF_MODE,
-    CONF_PIN,
-    CONF_OUTPUT,
+from esphome.components.audio_dac import AudioDac
+from esphome.const import (
+    CONF_ID,
     CONF_INPUT,
-    CONF_INVERTED
+    CONF_INVERTED,
+    CONF_MODE,
+    CONF_OUTPUT,
+    CONF_PIN,
 )
 from esphome import pins
 
@@ -21,10 +20,10 @@ PCM5122 = pcm5122_ns.class_("PCM5122", AudioDac, cg.Component, i2c.I2CDevice)
 CONF_PCM5122 = "pcm5122"
 
 
-PCMGPIOPin = pcm5122_ns.class_( 
-    "PCMGPIOPin", 
-    cg.GPIOPin, 
-    cg.Parented.template(PCM5122)
+PCMGPIOPin = pcm5122_ns.class_(
+    "PCMGPIOPin",
+    cg.GPIOPin,
+    cg.Parented.template(PCM5122),
 )
 
 CONFIG_SCHEMA = (
@@ -51,7 +50,7 @@ PIN_SCHEMA = cv.All(
         cv.GenerateID(): cv.declare_id(PCMGPIOPin),
         cv.Required(CONF_PCM5122): cv.use_id(PCM5122),
         cv.Required(CONF_PIN): cv.int_range(min=3, max=6),
-        cv.Optional(CONF_MODE, default=CONF_OUTPUT): cv.All(
+        cv.Optional(CONF_MODE, default={CONF_OUTPUT: True, CONF_INPUT: False}): cv.All(
             {
                 cv.Optional(CONF_INPUT, default=False): cv.boolean,
                 cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
@@ -72,6 +71,7 @@ async def pcm5122_pin_to_code(config):
     cg.add(var.set_inverted(config[CONF_INVERTED]))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/components/pcm5122/pcm5122.cpp
+++ b/components/pcm5122/pcm5122.cpp
@@ -9,43 +9,36 @@ namespace pcm5122 {
 
 static const char *const TAG = "pcm5122";
 
-static const uint8_t PCM5122_REG00_PAGE_SELECT = 0x00;  // Page Select
-
 void PCM5122::setup() {
   ESP_LOGCONFIG(TAG, "Setting up PCM5122...");
-  // select page 0
-  this->reg(PCM5122_REG00_PAGE_SELECT) = 0x00;
 
-  uint8_t chd1 = this->reg(0x09).get();
-  uint8_t chd2 = this->reg(0x10).get();
-  if (chd1 == 0x00 && chd2 == 0x00) {
-    ESP_LOGD(TAG, "PCM5122 chip found.");
-  } else {
-    ESP_LOGD(TAG, "PCM5122 chip not found.");
+  // Select page 0 and verify chip presence via I2C ACK
+  if (!this->write_byte(PCM5122_REG_PAGE_SELECT, 0x00)) {
+    ESP_LOGE(TAG, "PCM5122 not found");
+    this->status_set_error(LOG_STR("PCM5122 not found"));
     this->mark_failed();
     return;
   }
 
-  // RESET
-  this->reg(0x01) = 0x10;
+  // Reset
+  this->reg(PCM5122_REG_RESET) = 0x10;
   delay(20);
-  this->reg(0x01) = 0x00;
+  this->reg(PCM5122_REG_RESET) = 0x00;
 
-  uint8_t err_detect = this->reg(0x25).get();
-  // set 'Ignore Clock Halt Detection'
-  err_detect |= (1 << 3);
-  // enable Clock Divider Autoset
-  err_detect &= ~(1 << 1);
-  this->reg(0x25) = err_detect;
+  // Ignore clock halt detection; enable clock divider autoset
+  uint8_t err_detect = this->reg(PCM5122_REG_ERROR_DETECT).get();
+  err_detect |= (1 << 3);   // ignore clock halt
+  err_detect &= ~(1 << 1);  // enable clock divider autoset
+  this->reg(PCM5122_REG_ERROR_DETECT) = err_detect;
 
-  // set 32bit - I2S
-  this->reg(0x28) = 3;  // 32bits
+  // 32-bit I2S
+  this->reg(PCM5122_REG_AUDIO_FORMAT) = 3;
 
-  // 001: The PLL reference clock is BCK
-  uint8_t pll_ref = this->reg(0x0D).get();
+  // PLL reference clock: BCK (001)
+  uint8_t pll_ref = this->reg(PCM5122_REG_PLL_REF).get();
   pll_ref &= ~(7 << 4);
   pll_ref |= (1 << 4);
-  this->reg(0x0D) = pll_ref;
+  this->reg(PCM5122_REG_PLL_REF) = pll_ref;
 
   this->set_mute_on();
 }
@@ -67,7 +60,7 @@ bool PCM5122::set_mute_on() {
 }
 
 bool PCM5122::set_volume(float volume) {
-  this->volume_ = clamp<float>(volume, 0.0, 1.0);
+  this->volume_ = clamp<float>(volume, 0.0f, 1.0f);
   return this->write_volume_();
 }
 
@@ -77,7 +70,7 @@ float PCM5122::volume() { return this->volume_; }
 
 bool PCM5122::write_mute_() {
   uint8_t mute_byte = this->is_muted() ? 0x11 : 0x00;
-  if (!this->write_byte(PCM5122_REG00_PAGE_SELECT, 0x00) || !this->write_byte(0x03, mute_byte)) {
+  if (!this->write_byte(PCM5122_REG_PAGE_SELECT, 0x00) || !this->write_byte(PCM5122_REG_MUTE, mute_byte)) {
     ESP_LOGE(TAG, "Writing mute failed");
     return false;
   }
@@ -85,15 +78,17 @@ bool PCM5122::write_mute_() {
 }
 
 bool PCM5122::write_volume_() {
-  const uint8_t dvc_min_byte = 0x44;  //   0x00: 24 dB ; 0x30:   0dB
-  const uint8_t dvc_max_byte = 0x99;  //   0xFF:  mute ; 0x94: -50dB
+  // DVOL register: 0x00 = +24 dB, 0x30 = 0 dB, 0xFF = mute (-0.5 dB/step)
+  const uint8_t dvol_max_volume = 0x44;  // -10 dB at full scale
+  const uint8_t dvol_min_volume = 0x99;  // -52.5 dB at minimum
 
-  const uint8_t volume_byte = dvc_min_byte + ((1. - this->volume_) * (dvc_max_byte - dvc_min_byte) + 0.5);
+  const uint8_t volume_byte =
+      dvol_max_volume + static_cast<uint8_t>((1.0f - this->volume_) * (dvol_min_volume - dvol_max_volume) + 0.5f);
 
-  ESP_LOGD(TAG, "Setting volume to 0x%.2x", volume_byte & 0xFF);
+  ESP_LOGD(TAG, "Setting volume to 0x%.2x", volume_byte);
 
-  if ((!this->write_byte(PCM5122_REG00_PAGE_SELECT, 0x00)) || (!this->write_byte(0x3D, volume_byte)) ||
-      (!this->write_byte(0x3E, volume_byte))) {
+  if (!this->write_byte(PCM5122_REG_PAGE_SELECT, 0x00) || !this->write_byte(PCM5122_REG_DVOL_LEFT, volume_byte) ||
+      !this->write_byte(PCM5122_REG_DVOL_RIGHT, volume_byte)) {
     ESP_LOGE(TAG, "Writing volume failed");
     return false;
   }

--- a/components/pcm5122/pcm5122.h
+++ b/components/pcm5122/pcm5122.h
@@ -9,6 +9,21 @@
 namespace esphome {
 namespace pcm5122 {
 
+// Page 0 register addresses
+static const uint8_t PCM5122_REG_PAGE_SELECT = 0x00;
+static const uint8_t PCM5122_REG_RESET = 0x01;
+static const uint8_t PCM5122_REG_MUTE = 0x03;
+static const uint8_t PCM5122_REG_GPIO_ENABLE = 0x08;
+static const uint8_t PCM5122_REG_PLL_REF = 0x0D;
+static const uint8_t PCM5122_REG_ERROR_DETECT = 0x25;
+static const uint8_t PCM5122_REG_AUDIO_FORMAT = 0x28;
+static const uint8_t PCM5122_REG_DVOL_LEFT = 0x3D;
+static const uint8_t PCM5122_REG_DVOL_RIGHT = 0x3E;
+static const uint8_t PCM5122_REG_GPIO_OUTPUT_SELECT = 0x50;  // Base address; GPIO n uses offset n-1
+static const uint8_t PCM5122_REG_GPIO_OUTPUT = 0x56;
+static const uint8_t PCM5122_REG_GPIO_INVERT = 0x57;
+static const uint8_t PCM5122_REG_GPIO_INPUT = 0x77;
+
 class PCM5122 : public audio_dac::AudioDac, public Component, public i2c::I2CDevice {
  public:
   void setup() override;

--- a/components/pcm5122/pcm_gpio.cpp
+++ b/components/pcm5122/pcm_gpio.cpp
@@ -8,35 +8,35 @@ namespace pcm5122 {
 static const char *const TAG = "pcm5122.gpio";
 
 void PCMGPIOPin::setup() {
-  // set input/output mode for pin in register 0x08
-  uint8_t curr = this->parent_->reg(0x08).get();
+  // Configure input/output mode in the GPIO enable register
+  uint8_t curr = this->parent_->reg(PCM5122_REG_GPIO_ENABLE).get();
   if (this->flags_ & gpio::FLAG_INPUT) {
-    this->parent_->reg(0x08) = curr & ~(1 << (this->pin_ - 1));
+    this->parent_->reg(PCM5122_REG_GPIO_ENABLE) = curr & ~(1 << (this->pin_ - 1));
   } else if (this->flags_ & gpio::FLAG_OUTPUT) {
-    this->parent_->reg(0x08) = curr | (1 << (this->pin_ - 1));
-    // set pin to be used as GPIO
-    this->parent_->reg(0x50 + (this->pin_ - 1)) = 0x02;
-    // set / clear inversion bit
-    curr = this->parent_->reg(0x57).get();
+    this->parent_->reg(PCM5122_REG_GPIO_ENABLE) = curr | (1 << (this->pin_ - 1));
+    // Set pin to GPIO output mode
+    this->parent_->reg(PCM5122_REG_GPIO_OUTPUT_SELECT + (this->pin_ - 1)) = 0x02;
+    // Configure inversion
+    curr = this->parent_->reg(PCM5122_REG_GPIO_INVERT).get();
     if (this->inverted_) {
-      this->parent_->reg(0x57) = curr | (1 << (this->pin_ - 1));
+      this->parent_->reg(PCM5122_REG_GPIO_INVERT) = curr | (1 << (this->pin_ - 1));
     } else {
-      this->parent_->reg(0x57) = curr & ~(1 << (this->pin_ - 1));
+      this->parent_->reg(PCM5122_REG_GPIO_INVERT) = curr & ~(1 << (this->pin_ - 1));
     }
   }
 }
 
 void PCMGPIOPin::digital_write(bool value) {
-  uint8_t curr = this->parent_->reg(0x56).get();
+  uint8_t curr = this->parent_->reg(PCM5122_REG_GPIO_OUTPUT).get();
   if (value) {
-    this->parent_->reg(0x56) = curr | (1 << (this->pin_ - 1));
+    this->parent_->reg(PCM5122_REG_GPIO_OUTPUT) = curr | (1 << (this->pin_ - 1));
   } else {
-    this->parent_->reg(0x56) = curr & ~(1 << (this->pin_ - 1));
+    this->parent_->reg(PCM5122_REG_GPIO_OUTPUT) = curr & ~(1 << (this->pin_ - 1));
   }
 }
 
 bool PCMGPIOPin::digital_read() {
-  optional<uint8_t> read = this->parent_->read_byte(0x77);
+  optional<uint8_t> read = this->parent_->read_byte(PCM5122_REG_GPIO_INPUT);
   if (read.has_value()) {
     this->value_ = !!(read.value() & (1 << (this->pin_ - 1))) != this->inverted_;
   }


### PR DESCRIPTION
## Summary

Prepares the `pcm5122` audio DAC component for submission to upstream ESPHome, addressing coding standard requirements from the ESPHome contribution guide.

## Changes

### `audio_dac.py`
- Fixed import ordering and removed unused imports (`automation`, `audio_dac_ns`)
- Fixed `CONF_MODE` default in `PIN_SCHEMA` from bare string `CONF_OUTPUT` to proper dict `{CONF_OUTPUT: True, CONF_INPUT: False}`, matching ESPHome GPIO pin conventions
- Added trailing commas and fixed whitespace/newline issues

### `pcm5122.h`
- Added named `PCM5122_REG_*` constants for all register addresses, replacing magic numbers throughout the driver

### `pcm5122.cpp`
- Replaced all magic register numbers (`0x25`, `0x3D`, etc.) with named `PCM5122_REG_*` constants
- Improved chip detection: replaced unreliable "read two registers and check for zero" approach with I2C ACK-based detection using `write_byte()`, reporting failure via `status_set_error()` + `mark_failed()`
- Used `0.0f`/`1.0f` float literals and `static_cast<uint8_t>` in volume calculation
- Clarified DVOL register semantics in comments

### `pcm_gpio.cpp`
- Replaced all magic register numbers with named `PCM5122_REG_*` constants

## Test plan

- [x] Build `config/satellite1.yaml` — confirms Python schema and C++ compile cleanly
- [x] Flash to Satellite1 hardware and verify audio output works
- [x] Verify volume control works across full range
- [x] Verify mute/unmute works correctly
- [ ] Verify PCM5122 GPIO pins (3–6) function as outputs and inputs
- [x] Verify I2C failure is correctly reported when chip is absent