### PR TITLE
esphome 2026.4 bump

### DIFF
--- a/components/i2s_audio/__init__.py
+++ b/components/i2s_audio/__init__.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass, field
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components.esp32 import (
@@ -44,20 +46,17 @@ CONF_I2S_MODE = "i2s_mode"
 CONF_PRIMARY = "primary"
 CONF_SECONDARY = "secondary"
 
-CONF_I2S_ACCESS_MODE = "access_mode"
 CONF_I2S_COMM_FMT = "i2s_comm_fmt"
 CONF_PDM = "pdm"
+CONF_ADC_TYPE = "adc_type"
 
 CONF_USE_APLL = "use_apll"
-CONF_BITS_PER_CHANNEL = "bits_per_channel"
 CONF_MCLK_MULTIPLE = "mclk_multiple"
 CONF_MONO = "mono"
 CONF_LEFT = "left"
 CONF_RIGHT = "right"
 CONF_STEREO = "stereo"
 CONF_BOTH = "both"
-
-CONF_USE_LEGACY = "use_legacy"
 
 i2s_audio_ns = cg.esphome_ns.namespace("i2s_audio")
 I2SPortComponent = i2s_audio_ns.class_("I2SPortComponent", cg.Component)
@@ -67,10 +66,6 @@ I2SAudioBase = i2s_audio_ns.class_(
 
 I2SAudioIn = i2s_audio_ns.class_("I2SAudioIn", I2SAudioBase)
 I2SAudioOut = i2s_audio_ns.class_("I2SAudioOut", I2SAudioBase)
-
-I2SAccessMode = i2s_audio_ns.enum("I2SAccessMode", is_class=True)
-ACCESS_MODES = {"exclusive": I2SAccessMode.EXCLUSIVE, "duplex": I2SAccessMode.DUPLEX}
-
 
 i2s_mode_t = cg.global_ns.enum("i2s_mode_t")
 I2S_MODE_OPTIONS = {
@@ -126,15 +121,6 @@ I2S_BITS_PER_SAMPLE = {
     32: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_32BIT,
 }
 
-i2s_bits_per_chan_t = cg.global_ns.enum("i2s_bits_per_chan_t")
-I2S_BITS_PER_CHANNEL = {
-    "default": i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_DEFAULT,
-    8: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_8BIT,
-    16: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_16BIT,
-    24: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_24BIT,
-    32: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_32BIT,
-}
-
 i2s_slot_bit_width_t = cg.global_ns.enum("i2s_slot_bit_width_t")
 I2S_SLOT_BIT_WIDTH = {
     "default": i2s_slot_bit_width_t.I2S_SLOT_BIT_WIDTH_AUTO,
@@ -176,20 +162,6 @@ def validate_mclk_divisible_by_3(config):
         )
     return config
 
-# Key for storing legacy driver setting in CORE.data
-I2S_USE_LEGACY_DRIVER_KEY = "i2s_use_legacy_driver"
-
-
-def _get_use_legacy_driver():
-    """Get the legacy driver setting from CORE.data."""
-    return CORE.data.get(I2S_USE_LEGACY_DRIVER_KEY)
-
-
-def _set_use_legacy_driver(value: bool) -> None:
-    """Set the legacy driver setting in CORE.data."""
-    CORE.data[I2S_USE_LEGACY_DRIVER_KEY] = value
-
-
 def i2s_audio_component_schema(
     class_: MockObjClass,
     *,
@@ -211,10 +183,6 @@ def i2s_audio_component_schema(
                 _validate_bits, cv.one_of(*I2S_BITS_PER_SAMPLE)
             ),
             cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
-            cv.Optional(CONF_BITS_PER_CHANNEL, default="default"): cv.All(
-                cv.Any(cv.float_with_unit("bits", "bit"), "default"),
-                cv.one_of(*I2S_BITS_PER_CHANNEL),
-            ),
             cv.Optional(CONF_MCLK_MULTIPLE, default=256): cv.one_of(*I2S_MCLK_MULTIPLE),
             cv.Optional(CONF_I2S_COMM_FMT, default="stand_i2s"): cv.one_of(
                         *I2S_COMM_FMT_OPTIONS, lower=True
@@ -223,80 +191,91 @@ def i2s_audio_component_schema(
     )
 
 
-def use_legacy():
-    return _get_use_legacy_driver()
-
-
 async def register_i2s_audio_component(var, config):
     await cg.register_parented(var, config[CONF_I2S_AUDIO_ID])
-    if use_legacy():
-        #cg.add(var.set_i2s_mode(I2S_MODE_OPTIONS[config[CONF_I2S_MODE]]))
-        cg.add(var.set_channel(I2S_CHANNELS[config[CONF_CHANNEL]]))
-        cg.add(
-            var.set_bits_per_sample(I2S_BITS_PER_SAMPLE[config[CONF_BITS_PER_SAMPLE]])
-        )
-        cg.add(
-            var.set_bits_per_channel(
-                I2S_BITS_PER_CHANNEL[config[CONF_BITS_PER_CHANNEL]]
-            )
-        )
-        cg.add(
-                var.set_i2s_comm_fmt(I2S_COMM_FMT_OPTIONS[config[CONF_I2S_COMM_FMT]])
-            )
-    else:
-        #cg.add(var.set_i2s_role(I2S_ROLE_OPTIONS[config[CONF_I2S_MODE]]))
-        slot_mode = config[CONF_CHANNEL]
-        if slot_mode != CONF_STEREO:
-            slot_mode = CONF_MONO
-        slot_mask = config[CONF_CHANNEL]
-        if slot_mask not in [CONF_LEFT, CONF_RIGHT]:
-            slot_mask = CONF_BOTH
-        cg.add(var.set_slot_mode(I2S_SLOT_MODE[slot_mode]))
-        cg.add(var.set_std_slot_mask(I2S_STD_SLOT_MASK[slot_mask]))
-        cg.add(var.set_slot_bit_width(I2S_SLOT_BIT_WIDTH[config[CONF_BITS_PER_SAMPLE]]))
-        fmt = "std"  # equals stand_i2s, stand_pcm_long, i2s_msb, pcm_long
-        if config[CONF_I2S_COMM_FMT] in ["stand_msb", "i2s_lsb"]:
-            fmt = "msb"
-        elif config[CONF_I2S_COMM_FMT] in ["stand_pcm_short", "pcm_short", "pcm"]:
-            fmt = "pcm"
-        cg.add(var.set_i2s_comm_fmt(fmt))
+    slot_mode = config[CONF_CHANNEL]
+    if slot_mode != CONF_STEREO:
+        slot_mode = CONF_MONO
+    slot_mask = config[CONF_CHANNEL]
+    if slot_mask not in [CONF_LEFT, CONF_RIGHT]:
+        slot_mask = CONF_BOTH
+    cg.add(var.set_slot_mode(I2S_SLOT_MODE[slot_mode]))
+    cg.add(var.set_std_slot_mask(I2S_STD_SLOT_MASK[slot_mask]))
+    cg.add(var.set_slot_bit_width(I2S_SLOT_BIT_WIDTH[config[CONF_BITS_PER_SAMPLE]]))
+    fmt = "std"  # equals stand_i2s, stand_pcm_long, i2s_msb, pcm_long
+    if config[CONF_I2S_COMM_FMT] in ["stand_msb", "i2s_lsb"]:
+        fmt = "msb"
+    elif config[CONF_I2S_COMM_FMT] in ["stand_pcm_short", "pcm_short", "pcm"]:
+        fmt = "pcm"
+    cg.add(var.set_i2s_comm_fmt(fmt))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
     cg.add(var.set_use_apll(config[CONF_USE_APLL]))
     cg.add(var.set_mclk_multiple(I2S_MCLK_MULTIPLE[config[CONF_MCLK_MULTIPLE]]))
     cg.add(var.register_at_parent())
 
 
-def validate_use_legacy(value):
-    if CONF_USE_LEGACY in value:
-        existing_value = _get_use_legacy_driver()
-        if (existing_value is not None) and (existing_value != value[CONF_USE_LEGACY]):
-            raise cv.Invalid(
-                f"All i2s_audio components must set {CONF_USE_LEGACY} to the same value."
-            )
-        if (not value[CONF_USE_LEGACY]) and (CORE.using_arduino):
-            raise cv.Invalid("Arduino supports only the legacy i2s driver")
-        _set_use_legacy_driver(value[CONF_USE_LEGACY])
-    elif CORE.using_arduino:
-        _set_use_legacy_driver(True)
-    return value
-
-
-CONFIG_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(I2SPortComponent),
-            cv.Required(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
-            cv.Optional(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
-            cv.Optional(CONF_I2S_MCLK_PIN): pins.internal_gpio_output_pin_number,
-            cv.Optional(CONF_I2S_ACCESS_MODE, default="exclusive"): cv.enum(ACCESS_MODES),
-            cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.one_of(
-                *I2S_MODE_OPTIONS, lower=True
-            ),
-            cv.Optional(CONF_USE_LEGACY): cv.boolean,
-        }
-    ),
-    validate_use_legacy,
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(I2SPortComponent),
+        cv.Required(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_MCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.one_of(
+            *I2S_MODE_OPTIONS, lower=True
+        ),
+    }
 )
+
+@dataclass
+class I2SAudioData:
+    """I2S audio component state stored in CORE.data."""
+
+    port_map: dict[str, int] = field(default_factory=dict)
+
+
+def _get_data() -> I2SAudioData:
+    if CONF_I2S_AUDIO not in CORE.data:
+        CORE.data[CONF_I2S_AUDIO] = I2SAudioData()
+    return CORE.data[CONF_I2S_AUDIO]
+
+
+def _assign_ports() -> None:
+    """Assign I2S port numbers, prioritizing instances with microphone children.
+
+    Microphones (especially PDM) require port 0 on most ESP32 variants.
+    This runs once and stores the mapping in CORE.data.
+    """
+    data = _get_data()
+    if data.port_map:
+        return
+
+    full_config = fv.full_config.get()
+    i2s_configs = full_config[CONF_I2S_AUDIO]
+
+    # Find i2s_audio instances with microphones that require port 0
+    # (PDM and internal ADC only work on I2S port 0)
+    port0_parent_id = None
+    for mic_config in full_config.get("microphone", []):
+        if CONF_I2S_AUDIO_ID not in mic_config:
+            continue
+        if mic_config.get(CONF_PDM) or mic_config.get(CONF_ADC_TYPE) == "internal":
+            if port0_parent_id is not None:
+                raise cv.Invalid(
+                    "Only one PDM/ADC microphone is supported (requires I2S port 0)"
+                )
+            port0_parent_id = str(mic_config[CONF_I2S_AUDIO_ID])
+
+    # Assign ports: port 0 parent first (if any), rest get sequential
+    next_port = 0
+    if port0_parent_id is not None:
+        data.port_map[port0_parent_id] = next_port
+        next_port += 1
+    for config in i2s_configs:
+        config_id = str(config[CONF_ID])
+        if config_id != port0_parent_id:
+            data.port_map[config_id] = next_port
+            next_port += 1
+
 
 def _final_validate(_):
     i2s_audio_configs = fv.full_config.get()[CONF_I2S_AUDIO]
@@ -307,6 +286,7 @@ def _final_validate(_):
         raise cv.Invalid(
             f"Only {I2S_PORTS[variant]} I2S audio ports are supported on {variant}"
         )
+    _assign_ports()
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate
@@ -316,16 +296,15 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
+    # Assign I2S port from _final_validate computed mapping
+    data = _get_data()
+    if (port := data.port_map.get(str(config[CONF_ID]))) is None:
+        raise ValueError(f"No I2S port assigned for {config[CONF_ID]}")
+    cg.add(var.set_port(port))
+
     # Re-enable ESP-IDF's I2S driver (excluded by default to save compile time)
     include_builtin_idf_component("esp_driver_i2s")
-
-    if use_legacy():
-        cg.add_define("USE_I2S_LEGACY")
-        # Legacy I2S API lives in the "driver" shim component (driver/i2s.h)
-        include_builtin_idf_component("driver")
-        cg.add(var.set_i2s_mode(I2S_MODE_OPTIONS[config[CONF_I2S_MODE]]))
-    else:
-        cg.add(var.set_i2s_role(I2S_ROLE_OPTIONS[config[CONF_I2S_MODE]]))
+    cg.add(var.set_i2s_role(I2S_ROLE_OPTIONS[config[CONF_I2S_MODE]]))
 
     # Helps avoid callbacks being skipped due to processor load
     add_idf_sdkconfig_option("CONFIG_I2S_ISR_IRAM_SAFE", True)
@@ -334,4 +313,3 @@ async def to_code(config):
         cg.add(var.set_bclk_pin(config[CONF_I2S_BCLK_PIN]))
     if CONF_I2S_MCLK_PIN in config:
         cg.add(var.set_mclk_pin(config[CONF_I2S_MCLK_PIN]))
-    cg.add(var.set_access_mode(config[CONF_I2S_ACCESS_MODE]))

--- a/components/i2s_audio/i2s_audio.cpp
+++ b/components/i2s_audio/i2s_audio.cpp
@@ -9,12 +9,7 @@ namespace i2s_audio {
 
 static const char *const TAG = "i2s_audio";
 
-#if defined(USE_ESP_IDF) && (ESP_IDF_VERSION_MAJOR >= 5)
-static const uint8_t I2S_NUM_MAX = SOC_I2S_NUM;  // because IDF 5+ took this away :(
-#endif
-
 static const size_t DMA_BUFFERS_COUNT = 4;
-static const size_t I2S_EVENT_QUEUE_COUNT = DMA_BUFFERS_COUNT + 1;
 
 void I2SAudioBase::dump_i2s_settings() const {
   std::string init_str = this->is_fixed_ ? "Fixed-CFG" : "Initial-CFG";
@@ -23,41 +18,18 @@ void I2SAudioBase::dump_i2s_settings() const {
   } else {
     ESP_LOGCONFIG(TAG, "I2S-Writer (%s):", init_str.c_str());
   }
-#ifdef USE_I2S_LEGACY
-
-  ESP_LOGCONFIG(TAG, "  sample-rate: %d bits_per_sample: %d", this->sample_rate_, this->bits_per_sample_);
-  ESP_LOGCONFIG(TAG, "  channel_fmt: %d channels: %d", this->channel_fmt_, this->num_of_channels());
-  ESP_LOGCONFIG(TAG, "  use_apll: %s", this->use_apll_ ? "yes" : "no");
-#else
   ESP_LOGCONFIG(TAG, "  sample-rate: %d slot_mode: %d slot_mask: %d slot_bit_width: %d", this->sample_rate_,
                 this->slot_mode_, this->std_slot_mask_, this->slot_bit_width_);
   ESP_LOGCONFIG(TAG, "  use_apll: %s", this->use_apll_ ? "yes" : "no");
-#endif
 }
 
 void I2SPortComponent::setup() {
-  static i2s_port_t next_port_num = I2S_NUM_0;
-
-  if (next_port_num >= I2S_NUM_MAX) {
-    ESP_LOGE(TAG, "Too many I2S Audio components!");
-    this->mark_failed();
-    return;
-  }
-
-  this->port_ = next_port_num;
-  next_port_num = (i2s_port_t) (next_port_num + 1);
-
-  ESP_LOGCONFIG(TAG, "Setting up I2S Audio...");
+  ESP_LOGCONFIG(TAG, "Setting up I2S Audio (port %d)...", (int) this->port_);
 }
 
 void I2SPortComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "I2SController:");
-#ifdef USE_I2S_LEGACY
-  ESP_LOGCONFIG(TAG, "  clk_mode: %s", this->i2s_mode_ == I2S_MODE_MASTER ? "internal" : "external");
-#else
   ESP_LOGCONFIG(TAG, "  role: %s", this->i2s_role_ == I2S_ROLE_MASTER ? "primary" : "secondary");
-#endif
-  ESP_LOGCONFIG(TAG, "  AccessMode: %s", this->access_mode_ == I2SAccessMode::DUPLEX ? "duplex" : "exclusive");
   ESP_LOGCONFIG(TAG, "  Port: %d", this->get_port());
   if (this->audio_in_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Reader registered.");
@@ -67,146 +39,6 @@ void I2SPortComponent::dump_config() {
   }
 }
 
-bool I2SPortComponent::claim_access_(uint8_t access) {
-  bool success = false;
-  this->lock();
-  if (this->access_mode_ == I2SAccessMode::DUPLEX) {
-    this->access_state_ |= access;
-    success = true;
-  } else {
-    if (this->access_state_ == I2SAccess::FREE) {
-      this->access_state_ = access;
-    }
-    success = this->access_state_ & access;
-  }
-  this->unlock();
-  return success;
-}
-
-bool I2SPortComponent::release_access_(uint8_t access) {
-  this->lock();
-  this->access_state_ = this->access_state_ & (~access);
-  this->unlock();
-  return true;
-}
-
-#ifdef USE_I2S_LEGACY
-bool I2SPortComponent::install_i2s_driver_(i2s_driver_config_t i2s_cfg, uint8_t access) {
-  bool success = false;
-  this->lock();
-  esph_log_d(TAG, "Install driver requested by %s", access == I2SAccess::RX ? "Reader" : "Writer");
-  if (this->access_state_ == I2SAccess::FREE || this->access_state_ == access) {
-    if (this->driver_loaded_) {
-      ESP_LOGW(TAG, "trying to load i2s driver twice");
-      return true;
-    }
-    if (this->access_mode_ == I2SAccessMode::DUPLEX) {
-      i2s_cfg.mode = (i2s_mode_t) (i2s_cfg.mode | I2S_MODE_TX | I2S_MODE_RX);
-    }
-    success = ESP_OK == i2s_driver_install(this->get_port(), &i2s_cfg, I2S_EVENT_QUEUE_COUNT, &this->i2s_event_queue_);
-    esph_log_d(TAG, "Installing driver : %s", success ? "yes" : "no");
-    i2s_pin_config_t pin_config = this->get_pin_config();
-    if (success) {
-      this->driver_loaded_ = true;
-      if (this->audio_in_ != nullptr) {
-        pin_config.data_in_num = this->audio_in_->get_din_pin();
-      }
-      if (this->audio_out_ != nullptr) {
-        pin_config.data_out_num = this->audio_out_->get_dout_pin();
-      }
-      success &= ESP_OK == i2s_set_pin(this->get_port(), &pin_config);
-      if (success) {
-        this->installed_cfg_ = i2s_cfg;
-      }
-    }
-  } else if (this->access_mode_ == I2SAccessMode::DUPLEX && this->driver_loaded_) {
-    success = this->validate_cfg_for_duplex_(i2s_cfg);
-    ESP_LOGW(TAG, "Driver already loaded, trying to validate duplex mode: %s", success ? "yes" : "no");
-    if (!success) {
-      ESP_LOGE(TAG, "incompatible i2s settings for duplex mode, access_state: %d", this->access_state_);
-    }
-  } else {
-    ESP_LOGE(TAG, "Unexpected i2s state: mode: %d access_state: %d access_request: %d", (int) this->access_mode_,
-             (int) this->access_state_, (int) access);
-  }
-  this->unlock();
-  return success;
-}
-
-bool I2SPortComponent::uninstall_i2s_driver_(uint8_t access) {
-  bool success = false;
-  this->lock();
-  // check that i2s is not occupied by others
-  if ((this->access_state_ & access) == access && (this->access_state_ & ~access) == 0) {
-    i2s_zero_dma_buffer(this->get_port());
-    esp_err_t err = i2s_driver_uninstall(this->get_port());
-    if (err == ESP_OK) {
-      success = true;
-      this->access_state_ = I2SAccess::FREE;
-      this->driver_loaded_ = false;
-    } else {
-      esph_log_e(TAG, "Couldn't unload driver");
-    }
-  } else {
-    // other component hasn't released yet
-    // don't uninstall driver, just release caller
-    esph_log_d(TAG, "Other component hasn't released");
-    this->access_state_ = this->access_state_ & (~access);
-  }
-  this->unlock();
-  return success;
-}
-
-bool I2SPortComponent::validate_cfg_for_duplex_(i2s_driver_config_t &i2s_cfg) {
-  i2s_driver_config_t &installed = this->installed_cfg_;
-  return (installed.sample_rate == i2s_cfg.sample_rate && installed.bits_per_chan == i2s_cfg.bits_per_chan);
-}
-
-i2s_driver_config_t I2SAudioBase::get_i2s_cfg(i2s_mode_t i2s_mode) const {
-  uint8_t mode = ((uint8_t) i2s_mode) | (this->i2s_access_ == I2SAccess::RX ? I2S_MODE_RX : I2S_MODE_TX);
-
-  if (this->pdm_) {
-    mode = (i2s_mode_t) (mode | I2S_MODE_PDM);
-  }
-
-  i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) mode,
-      .sample_rate = this->sample_rate_,
-      .bits_per_sample = this->bits_per_sample_,
-      .channel_format = this->channel_fmt_,
-      .communication_format = I2S_COMM_FORMAT_STAND_I2S,
-      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
-      .dma_buf_count = DMA_BUFFERS_COUNT,
-      .dma_buf_len = 240,
-      .use_apll = false,
-      .tx_desc_auto_clear = true,
-      .fixed_mclk = I2S_PIN_NO_CHANGE,
-      .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-      .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
-#if SOC_I2S_SUPPORTS_TDM
-      .chan_mask = I2S_CHANNEL_MONO,
-      .total_chan = 0,
-      .left_align = false,
-      .big_edin = false,
-      .bit_order_msb = false,
-      .skip_msk = false,
-#endif
-  };
-  return config;
-}
-
-void I2SPortComponent::process_i2s_events(bool &tx_dma_underflow) {
-  i2s_event_t i2s_event;
-  while (xQueueReceive(this->i2s_event_queue_, &i2s_event, 0)) {
-    if (i2s_event.type == I2S_EVENT_TX_Q_OVF) {
-      tx_dma_underflow = true;
-    }
-  }
-}
-
-#endif  // USE_I2S_LEGACY
-
-#ifndef USE_I2S_LEGACY
 i2s_std_gpio_config_t I2SPortComponent::get_pin_config() const {
   return {.mclk = (gpio_num_t) this->mclk_pin_,
           .bclk = (gpio_num_t) this->bclk_pin_,
@@ -263,10 +95,8 @@ bool I2SPortComponent::init_driver_(i2s_std_config_t std_cfg) {
   this->unlock();
   return true;
 }
-#endif
 
 bool I2SAudioOut::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
-#ifndef USE_I2S_LEGACY
   if (this->parent_->tx_handle_ == nullptr) {
     if (this->parent_->rx_handle_ != nullptr) {
       ESP_LOGE(TAG, "Trying to start I2S-TX channel, but RX handle is available. This is not allowed.");
@@ -308,29 +138,10 @@ bool I2SAudioOut::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
     this->callbacks_registered_ = false;
     return false;
   }
-#else
-  if (!this->claim_i2s_access()) {
-    return false;
-  }
-
-  i2s_driver_config_t config = this->get_i2s_cfg(this->parent_->i2s_mode_);
-  if (!this->parent_->install_i2s_driver_(config, I2SAccess::TX)) {
-    this->parent_->release_access_(I2SAccess::TX);
-    return false;
-  }
-
-#endif
   return true;
 }
 
 bool I2SAudioOut::stop_i2s_channel_() {
-#ifdef USE_I2S_LEGACY
-  if (!this->parent_->uninstall_i2s_driver_(I2SAccess::TX)) {
-    this->parent_->release_access_(I2SAccess::TX);
-    return false;
-  }
-  this->parent_->release_access_(I2SAccess::TX);
-#else
   if (this->parent_->tx_handle_ == nullptr) {
     ESP_LOGE(TAG, "Trying to stop I2S-TX channel, but handle is nullptr.");
     return false;
@@ -350,22 +161,10 @@ bool I2SAudioOut::stop_i2s_channel_() {
   }
   this->parent_->tx_handle_ = nullptr;
   this->callbacks_registered_ = false;
-#endif
   return true;
 }
 
 bool I2SAudioIn::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
-#ifdef USE_I2S_LEGACY
-  if (!this->claim_i2s_access()) {
-    return false;
-  }
-
-  i2s_driver_config_t config = this->get_i2s_cfg(this->parent_->i2s_mode_);
-  if (!this->parent_->install_i2s_driver_(config, I2SAccess::RX)) {
-    this->parent_->release_access_(I2SAccess::RX);
-    return false;
-  }
-#else
   if (this->parent_->rx_handle_ == nullptr) {
     if (this->parent_->tx_handle_ != nullptr) {
       ESP_LOGE(TAG, "Trying to start I2S-RX channel, but TX handle is available. This is not allowed.");
@@ -396,18 +195,10 @@ bool I2SAudioIn::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
     i2s_del_channel(this->parent_->rx_handle_);
     return false;
   }
-#endif
   return true;
 }
 
 bool I2SAudioIn::stop_i2s_channel_() {
-#ifdef USE_I2S_LEGACY
-  if (!this->parent_->uninstall_i2s_driver_(I2SAccess::RX)) {
-    this->parent_->release_access_(I2SAccess::RX);
-    return false;
-  }
-  this->parent_->release_access_(I2SAccess::RX);
-#else
   if (this->parent_->rx_handle_ == nullptr) {
     ESP_LOGE(TAG, "Trying to stop I2S-RX channel, but handle is nullptr.");
     return false;
@@ -426,7 +217,6 @@ bool I2SAudioIn::stop_i2s_channel_() {
     return false;
   }
   this->parent_->rx_handle_ = nullptr;
-#endif
   return true;
 }
 

--- a/components/i2s_audio/i2s_audio.cpp
+++ b/components/i2s_audio/i2s_audio.cpp
@@ -24,7 +24,7 @@ void I2SAudioBase::dump_i2s_settings() const {
 }
 
 void I2SPortComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up I2S Audio (port %d)...", (int) this->port_);
+  ESP_LOGCONFIG(TAG, "Setting up I2S Audio (port %d)...", (int)this->port_);
 }
 
 void I2SPortComponent::dump_config() {

--- a/components/i2s_audio/i2s_audio.cpp
+++ b/components/i2s_audio/i2s_audio.cpp
@@ -23,9 +23,7 @@ void I2SAudioBase::dump_i2s_settings() const {
   ESP_LOGCONFIG(TAG, "  use_apll: %s", this->use_apll_ ? "yes" : "no");
 }
 
-void I2SPortComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up I2S Audio (port %d)...", (int)this->port_);
-}
+void I2SPortComponent::setup() { ESP_LOGCONFIG(TAG, "Setting up I2S Audio (port %d)...", (int) this->port_); }
 
 void I2SPortComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "I2SController:");

--- a/components/i2s_audio/i2s_audio.h
+++ b/components/i2s_audio/i2s_audio.h
@@ -5,16 +5,11 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
-#ifdef USE_I2S_LEGACY
-#include <driver/i2s.h>
-#else
 #include <driver/i2s_std.h>
-#endif
 
 namespace esphome {
 namespace i2s_audio {
 
-enum class I2SAccessMode : uint8_t { EXCLUSIVE, DUPLEX };
 class I2SAccess {
  public:
   static constexpr uint8_t FREE = 0;
@@ -25,19 +20,7 @@ class I2SAccess {
 class I2SAudioBase {
  public:
   I2SAudioBase(uint8_t access) : i2s_access_(access) {}
-#ifdef USE_I2S_LEGACY
 
-  void set_channel(i2s_channel_fmt_t channel) { this->channel_fmt_ = channel; }
-  void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
-  void set_bits_per_channel(i2s_bits_per_chan_t bits_per_channel) { this->bits_per_channel_ = bits_per_channel; }
-  void set_i2s_comm_fmt(i2s_comm_format_t mode) { this->i2s_comm_fmt_ = mode; }
-  i2s_driver_config_t get_i2s_cfg(i2s_mode_t i2s_mode) const;
-  int num_of_channels() const {
-    return (this->channel_fmt_ == I2S_CHANNEL_FMT_ONLY_RIGHT || this->channel_fmt_ == I2S_CHANNEL_FMT_ONLY_LEFT) ? 1
-                                                                                                                 : 2;
-  }
-  uint8_t i2s_bits_per_sample() const { return this->bits_per_sample_; }
-#else
   void set_slot_mode(i2s_slot_mode_t slot_mode) { this->slot_mode_ = slot_mode; }
   void set_std_slot_mask(i2s_std_slot_mask_t std_slot_mask) { this->std_slot_mask_ = std_slot_mask; }
   void set_slot_bit_width(i2s_slot_bit_width_t slot_bit_width) { this->slot_bit_width_ = slot_bit_width; }
@@ -46,7 +29,6 @@ class I2SAudioBase {
     return (this->std_slot_mask_ == I2S_STD_SLOT_LEFT || this->std_slot_mask_ == I2S_STD_SLOT_RIGHT) ? 1 : 2;
   }
   uint8_t i2s_bits_per_sample() const { return (uint8_t) this->slot_bit_width_; }
-#endif
   void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
   void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
   void set_mclk_multiple(i2s_mclk_multiple_t mclk_multiple) { this->mclk_multiple_ = mclk_multiple; }
@@ -57,25 +39,12 @@ class I2SAudioBase {
   bool has_fixed_i2s_bitdepth() const { return this->is_fixed_; }
 
   virtual void register_at_parent() = 0;
-  bool validate_for_duplex(I2SAudioBase *other) const {
-    return ((this->i2s_access_ == other->i2s_access_) && (this->sample_rate_ == other->sample_rate_) &&
-            (this->mclk_multiple_ == other->mclk_multiple_) &&
-#ifdef USE_I2S_LEGACY
-            (this->channel_fmt_ == other->channel_fmt_) && (this->bits_per_sample_ == other->bits_per_sample_) &&
-            (this->bits_per_channel_ == other->bits_per_channel_)
-#else
-            (this->slot_mode_ == other->slot_mode_) && (this->std_slot_mask_ == other->std_slot_mask_) &&
-            (this->slot_bit_width_ == other->slot_bit_width_)
-#endif
-    );
-  }
 
-#ifndef USE_I2S_LEGACY
   i2s_std_clk_config_t get_std_clk_cfg() const {
     return {
         .sample_rate_hz = this->sample_rate_,
 #ifdef I2S_CLK_SRC_APLL
-        .clk_src = this->use_appll_ ? I2S_CLK_SRC_APLL : I2S_CLK_SRC_DEFAULT,
+        .clk_src = this->use_apll_ ? I2S_CLK_SRC_APLL : I2S_CLK_SRC_DEFAULT,
 #else
         .clk_src = I2S_CLK_SRC_DEFAULT,
 #endif
@@ -105,7 +74,7 @@ class I2SAudioBase {
     std_slot_cfg.slot_mask = this->std_slot_mask_;
     return std_slot_cfg;
   }
-#endif
+
  protected:
   virtual bool start_i2s_channel_(i2s_event_callbacks_t callbacks) = 0;
   virtual bool start_i2s_channel_() {
@@ -114,23 +83,14 @@ class I2SAudioBase {
   }
   virtual bool stop_i2s_channel_() = 0;
 
-#ifndef USE_I2S_LEGACY
   virtual bool IRAM_ATTR i2s_overflow_cb(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
     return true;
   }
-#endif
 
-#ifdef USE_I2S_LEGACY
-  i2s_channel_fmt_t channel_fmt_;
-  i2s_bits_per_sample_t bits_per_sample_;
-  i2s_bits_per_chan_t bits_per_channel_;
-  i2s_comm_format_t i2s_comm_fmt_;
-#else
   i2s_slot_mode_t slot_mode_;
   i2s_std_slot_mask_t std_slot_mask_;
   i2s_slot_bit_width_t slot_bit_width_;
   std::string i2s_comm_fmt_;
-#endif
   uint32_t sample_rate_;
   bool use_apll_;
   i2s_mclk_multiple_t mclk_multiple_;
@@ -148,24 +108,12 @@ class I2SPortComponent : public Component {
   void setup() override;
   void dump_config() override;
 
-#ifdef USE_I2S_LEGACY
-  i2s_pin_config_t get_pin_config() const {
-    return {
-        .mck_io_num = this->mclk_pin_,
-        .bck_io_num = this->bclk_pin_,
-        .ws_io_num = this->lrclk_pin_,
-        .data_out_num = I2S_PIN_NO_CHANGE,
-        .data_in_num = I2S_PIN_NO_CHANGE,
-    };
-  }
-  void process_i2s_events(bool &tx_dma_underflow);
-#else
   i2s_std_gpio_config_t get_pin_config() const;
-#endif
 
   void set_mclk_pin(int pin) { this->mclk_pin_ = pin; }
   void set_bclk_pin(int pin) { this->bclk_pin_ = pin; }
   void set_lrclk_pin(int pin) { this->lrclk_pin_ = pin; }
+  void set_port(int port) { this->port_ = (i2s_port_t) port; }
 
   void lock() { this->lock_.lock(); }
   bool try_lock() { return this->lock_.try_lock(); }
@@ -176,44 +124,20 @@ class I2SPortComponent : public Component {
   void set_audio_in(I2SAudioIn *comp_in) { this->audio_in_ = comp_in; }
   void set_audio_out(I2SAudioOut *comp_out) { this->audio_out_ = comp_out; }
 
-  void set_access_mode(I2SAccessMode access_mode) { this->access_mode_ = access_mode; }
-  bool is_exclusive() { return this->access_mode_ == I2SAccessMode::EXCLUSIVE; }
-
-#ifdef USE_I2S_LEGACY
-  void set_i2s_mode(i2s_mode_t mode) { this->i2s_mode_ = mode; }
-#else
   void set_i2s_role(i2s_role_t role) { this->i2s_role_ = role; }
   i2s_chan_handle_t get_tx_handle() const { return this->tx_handle_; }
   i2s_chan_handle_t get_rx_handle() const { return this->rx_handle_; }
-#endif
 
  protected:
   friend I2SAudioIn;
   friend I2SAudioOut;
 
   Mutex lock_;
-  I2SAccessMode access_mode_{I2SAccessMode::DUPLEX};
-  uint8_t access_state_{I2SAccess::FREE};
-
-  bool claim_access_(uint8_t access);
-  bool release_access_(uint8_t access);
-#ifdef USE_I2S_LEGACY
-  bool install_i2s_driver_(i2s_driver_config_t i2s_cfg, uint8_t access);
-  bool uninstall_i2s_driver_(uint8_t access);
-  bool validate_cfg_for_duplex_(i2s_driver_config_t &i2s_cfg);
-#else
   bool init_driver_(i2s_std_config_t std_cfg);
   bool free_driver_();
-#endif
 
   I2SAudioIn *audio_in_{nullptr};
   I2SAudioOut *audio_out_{nullptr};
-#ifdef USE_I2S_LEGACY
-  int mclk_pin_{I2S_PIN_NO_CHANGE};
-  int bclk_pin_{I2S_PIN_NO_CHANGE};
-  i2s_mode_t i2s_mode_{};
-  i2s_driver_config_t installed_cfg_{};
-#else
   i2s_role_t i2s_role_{};
   i2s_chan_handle_t tx_handle_{nullptr};
   i2s_chan_handle_t rx_handle_{nullptr};
@@ -221,7 +145,6 @@ class I2SPortComponent : public Component {
   int bclk_pin_{I2S_GPIO_UNUSED};
   int dout_pin_{I2S_GPIO_UNUSED};
   int din_pin_{I2S_GPIO_UNUSED};
-#endif
   int lrclk_pin_;
   i2s_port_t port_{};
   size_t dma_buffer_length_{240};
@@ -235,27 +158,8 @@ class I2SAudioIn : public I2SAudioBase, public Parented<I2SPortComponent> {
  public:
   I2SAudioIn() : I2SAudioBase(I2SAccess::RX) {}
 
-#ifdef USE_I2S_LEGACY
-  bool install_i2s_driver(i2s_driver_config_t i2s_cfg) {
-    return this->parent_->install_i2s_driver_(i2s_cfg, I2SAccess::RX);
-  }
-  bool uninstall_i2s_driver() { return this->parent_->uninstall_i2s_driver_(I2SAccess::RX); }
-  bool claim_i2s_access() { return this->parent_->claim_access_(I2SAccess::RX); }
-  bool release_i2s_access() { return this->parent_->release_access_(I2SAccess::RX); }
-  bool is_adjustable() { return !this->is_fixed_ && this->parent_->is_exclusive(); }
-
-#if SOC_I2S_SUPPORTS_ADC
-  void set_adc_channel(adc1_channel_t channel) {
-    this->adc_channel_ = channel;
-    this->use_internal_adc_ = true;
-  }
-#endif
-  void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
-  int8_t get_din_pin() { return this->din_pin_; }
-#else
   void set_din_pin(int8_t pin) { this->din_pin_ = (gpio_num_t) pin; }
   gpio_num_t get_din_pin() { return this->din_pin_; }
-#endif
 
   void register_at_parent() override { this->parent_->set_audio_in(this); }
 
@@ -263,40 +167,16 @@ class I2SAudioIn : public I2SAudioBase, public Parented<I2SPortComponent> {
   using I2SAudioBase::start_i2s_channel_;
   bool start_i2s_channel_(i2s_event_callbacks_t callbacks) override;
   bool stop_i2s_channel_() override;
-#ifdef USE_I2S_LEGACY
-#if SOC_I2S_SUPPORTS_ADC
-  adc1_channel_t adc_channel_{ADC1_CHANNEL_MAX};
-  bool use_internal_adc_{false};
-#endif
-  int8_t din_pin_{I2S_PIN_NO_CHANGE};
-#else
   gpio_num_t din_pin_{I2S_GPIO_UNUSED};
-#endif
 };
 
 class I2SAudioOut : public I2SAudioBase, public Parented<I2SPortComponent> {
  public:
   I2SAudioOut() : I2SAudioBase(I2SAccess::TX) {}
 
-#ifdef USE_I2S_LEGACY
-  bool install_i2s_driver(i2s_driver_config_t i2s_cfg) {
-    return this->parent_->install_i2s_driver_(i2s_cfg, I2SAccess::TX);
-  }
-  bool uninstall_i2s_driver() { return this->parent_->uninstall_i2s_driver_(I2SAccess::TX); }
-  bool claim_i2s_access() { return this->parent_->claim_access_(I2SAccess::TX); }
-  bool release_i2s_access() { return this->parent_->release_access_(I2SAccess::TX); }
-  bool is_adjustable() { return !this->is_fixed_ && this->parent_->is_exclusive(); }
-
-#if SOC_I2S_SUPPORTS_DAC
-  void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }
-#endif
-  void set_dout_pin(int8_t pin) { this->dout_pin_ = pin; }
-  int8_t get_dout_pin() { return this->dout_pin_; }
-  void set_i2s_comm_fmt(i2s_comm_format_t mode) { this->i2s_comm_fmt_ = mode; }
-#else
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = (gpio_num_t) pin; }
   gpio_num_t get_dout_pin() { return this->dout_pin_; }
-#endif
+
   size_t get_dma_buffer_size_bytes() const {
     return this->parent_->dma_buffer_length_ * this->num_of_channels() * this->i2s_bits_per_sample() / 8;
   }
@@ -305,22 +185,14 @@ class I2SAudioOut : public I2SAudioBase, public Parented<I2SPortComponent> {
 
   void register_at_parent() override { this->parent_->set_audio_out(this); }
 
-  bool is_adjustable() const { return !this->is_fixed_ && this->parent_->is_exclusive(); }
+  bool is_adjustable() const { return !this->is_fixed_; }
 
  protected:
   using I2SAudioBase::start_i2s_channel_;
   bool start_i2s_channel_(i2s_event_callbacks_t callbacks) override;
   bool stop_i2s_channel_() override;
-#ifdef USE_I2S_LEGACY
-#if SOC_I2S_SUPPORTS_DAC
-  i2s_dac_mode_t internal_dac_mode_{I2S_DAC_CHANNEL_DISABLE};
-#endif
-  int8_t dout_pin_{I2S_PIN_NO_CHANGE};
-  i2s_comm_format_t i2s_comm_fmt_;
-#else
   gpio_num_t dout_pin_{I2S_GPIO_UNUSED};
   bool callbacks_registered_{false};
-#endif
 };
 
 }  // namespace i2s_audio

--- a/components/i2s_audio/microphone/__init__.py
+++ b/components/i2s_audio/microphone/__init__.py
@@ -1,28 +1,28 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import audio, esp32, microphone
-from esphome.components.adc import ESP32_VARIANT_ADC1_PIN_TO_CHANNEL, validate_adc_pin
+from esphome.components.adc import validate_adc_pin
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BITS_PER_SAMPLE,
     CONF_CHANNEL,
     CONF_ID,
     CONF_NUM_CHANNELS,
-    CONF_NUMBER,
     CONF_SAMPLE_RATE,
 )
 
 from .. import (
+    CONF_ADC_TYPE,
     CONF_I2S_DIN_PIN,
     CONF_LEFT,
     CONF_MONO,
+    CONF_PDM,
     CONF_RIGHT,
     CONF_STEREO,
     I2SAudioIn,
     i2s_audio_component_schema,
     i2s_audio_ns,
     register_i2s_audio_component,
-    use_legacy,
     validate_mclk_divisible_by_3,
 )
 
@@ -31,9 +31,7 @@ CODEOWNERS = ["@gnumpi"]
 DEPENDENCIES = ["i2s_audio"]
 
 CONF_ADC_PIN = "adc_pin"
-CONF_ADC_TYPE = "adc_type"
 CONF_CORRECT_DC_OFFSET = "correct_dc_offset"
-CONF_PDM = "pdm"
 
 
 I2SAudioMicrophone = i2s_audio_ns.class_(
@@ -152,9 +150,8 @@ CONFIG_SCHEMA = cv.All(
 
 
 def _final_validate(config):
-    if not use_legacy():
-        if config[CONF_ADC_TYPE] == "internal":
-            raise cv.Invalid("Internal ADC is only compatible with legacy i2s driver.")
+    if config[CONF_ADC_TYPE] == "internal":
+        raise cv.Invalid("Internal ADC is no longer supported. Use an external I2S microphone instead.")
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate
@@ -166,13 +163,7 @@ async def to_code(config):
     await register_i2s_audio_component(var, config)
     await microphone.register_microphone(var, config)
 
-    if config[CONF_ADC_TYPE] == "internal":
-        variant = esp32.get_esp32_variant()
-        pin_num = config[CONF_ADC_PIN][CONF_NUMBER]
-        channel = ESP32_VARIANT_ADC1_PIN_TO_CHANNEL[variant][pin_num]
-        cg.add(var.set_adc_channel(channel))
-    else:
-        cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
-        cg.add(var.set_pdm(config[CONF_PDM]))
+    cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
+    cg.add(var.set_pdm(config[CONF_PDM]))
 
     cg.add(var.set_correct_dc_offset(config[CONF_CORRECT_DC_OFFSET]))

--- a/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -147,7 +147,6 @@ void I2SAudioMicrophone::loop() {
 void I2SAudioMicrophone::configure_stream_settings_() {
   uint8_t channel_count = this->num_of_channels();
   uint8_t bits_per_sample = 32;
-#ifndef USE_I2S_LEGACY
   if (this->slot_bit_width_ != I2S_SLOT_BIT_WIDTH_AUTO) {
     bits_per_sample = this->slot_bit_width_;
   }
@@ -155,7 +154,6 @@ void I2SAudioMicrophone::configure_stream_settings_() {
   if (this->slot_mode_ == I2S_SLOT_MODE_STEREO) {
     channel_count = 2;
   }
-#endif
   // report 16kHz sample rate, as the 48kHz i2s samples will be subsampled to 16kHz
   this->audio_stream_info_ = audio::AudioStreamInfo(bits_per_sample, channel_count, 16000);
 }
@@ -173,12 +171,8 @@ bool I2SAudioMicrophone::stop_driver_() { return this->stop_i2s_channel_(); }
 
 size_t I2SAudioMicrophone::read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait) {
   size_t bytes_read = 0;
-#ifdef USE_I2S_LEGACY
-  esp_err_t err = i2s_read(this->parent_->get_port(), buf, len, &bytes_read, ticks_to_wait);
-#else
   // i2s_channel_read expects the timeout value in ms, not ticks
   esp_err_t err = i2s_channel_read(this->parent_->get_rx_handle(), buf, len, &bytes_read, pdTICKS_TO_MS(ticks_to_wait));
-#endif
   if ((err != ESP_OK) && ((err != ESP_ERR_TIMEOUT) || (ticks_to_wait != 0))) {
     // Ignore ESP_ERR_TIMEOUT if ticks_to_wait = 0, as it will read the data on the next call
     if (!this->status_has_warning()) {

--- a/components/i2s_audio/speaker/__init__.py
+++ b/components/i2s_audio/speaker/__init__.py
@@ -26,7 +26,6 @@ from .. import (
     i2s_audio_component_schema,
     i2s_audio_ns,
     register_i2s_audio_component,
-    use_legacy,
     validate_mclk_divisible_by_3,
 )
 
@@ -161,13 +160,10 @@ CONFIG_SCHEMA = cv.All(
 
 
 def _final_validate(config):
-    if not use_legacy():
-        if config[CONF_DAC_TYPE] == "internal":
-            raise cv.Invalid("Internal DAC is only compatible with legacy i2s driver.")
-        if config[CONF_I2S_COMM_FMT] == "stand_max":
-            raise cv.Invalid(
-                "I2S standard max format only implemented with legacy i2s driver."
-            )
+    if config[CONF_DAC_TYPE] == "internal":
+        raise cv.Invalid("Internal DAC is no longer supported. Use an external I2S DAC instead.")
+    if config[CONF_I2S_COMM_FMT] == "stand_max":
+        raise cv.Invalid("I2S standard max format is no longer supported.")
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate
@@ -180,21 +176,13 @@ async def to_code(config):
     await register_i2s_audio_component(var, config)
     await speaker.register_speaker(var, config)
 
-    if config[CONF_DAC_TYPE] == "internal":
-        cg.add(var.set_internal_dac_mode(config[CONF_CHANNEL]))
-    else:
-        cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
-        if use_legacy():
-            cg.add(
-                var.set_i2s_comm_fmt(I2S_COMM_FMT_OPTIONS[config[CONF_I2S_COMM_FMT]])
-            )
-        else:
-            fmt = "std"  # equals stand_i2s, stand_pcm_long, i2s_msb, pcm_long
-            if config[CONF_I2S_COMM_FMT] in ["stand_msb", "i2s_lsb"]:
-                fmt = "msb"
-            elif config[CONF_I2S_COMM_FMT] in ["stand_pcm_short", "pcm_short", "pcm"]:
-                fmt = "pcm"
-            cg.add(var.set_i2s_comm_fmt(fmt))
+    cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
+    fmt = "std"  # equals stand_i2s, stand_pcm_long, i2s_msb, pcm_long
+    if config[CONF_I2S_COMM_FMT] in ["stand_msb", "i2s_lsb"]:
+        fmt = "msb"
+    elif config[CONF_I2S_COMM_FMT] in ["stand_pcm_short", "pcm_short", "pcm"]:
+        fmt = "pcm"
+    cg.add(var.set_i2s_comm_fmt(fmt))
 
     if config[CONF_TIMEOUT] != CONF_NEVER:
         cg.add(var.set_timeout(config[CONF_TIMEOUT]))

--- a/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -297,14 +297,12 @@ void I2SAudioSpeaker::speaker_task(void *params) {
     this_speaker->i2s_sent_time_queue_ = xQueueCreate(I2S_EVENT_QUEUE_COUNT, sizeof(int64_t));
   }
 
-#ifndef USE_I2S_LEGACY
   uint8_t *scaling_buffer = nullptr;
   if (expand_factor > 1) {
     // Allocate a scaling buffer to convert the audio data to the required bits per sample
     // The size of the scaling buffer is the same as the DMA buffer size, but with the expanded bits per sample
     scaling_buffer = new uint8_t[dma_buffer_size_bytes];
   }
-#endif
 
   if (this_speaker->send_esp_err_to_event_group_(this_speaker->allocate_buffers_(read_buffer_size, ring_buffer_size))) {
     // Failed to allocate buffers
@@ -442,16 +440,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
         const size_t bytes_to_write = read_buffer_size / dma_buffers_count;
         size_t bytes_written = 0;
 
-#ifdef USE_I2S_LEGACY
-        if (expand_factor == 1) {
-          i2s_write(this_speaker->parent_->get_port(), this_speaker->data_buffer_ + i * bytes_to_write, bytes_to_write,
-                    &bytes_written, pdMS_TO_TICKS(dma_buffer_duration_ms * 5));
-        } else if (expand_factor > 1) {
-          i2s_write_expand(this_speaker->parent_->get_port(), this_speaker->data_buffer_ + i * bytes_to_write,
-                           bytes_to_write, audio_stream_info.get_bits_per_sample(), this_speaker->bits_per_sample_,
-                           &bytes_written, pdMS_TO_TICKS(dma_buffer_duration_ms * 5));
-        }
-#else
         if (expand_factor == 1) {
           i2s_channel_write(this_speaker->parent_->get_tx_handle(), this_speaker->data_buffer_ + i * bytes_to_write,
                             bytes_to_write, &bytes_written, pdMS_TO_TICKS(dma_buffer_duration_ms * 5));
@@ -467,7 +455,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
                                 &bytes_written, pdMS_TO_TICKS(dma_buffer_duration_ms * 5));
           bytes_written /= 2;
         }
-#endif
 
         if (bytes_written != bytes_to_write) {
           xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_INVALID_SIZE);
@@ -475,19 +462,10 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
         // Track frames written for audio_output_callback_ (add after each DMA buffer write)
         frames_written += audio_stream_info.bytes_to_frames(bytes_written);
-
-#ifdef USE_I2S_LEGACY
-        // Legacy driver: call audio_output_callback_ directly after each write
-        if (bytes_written > 0) {
-          this_speaker->audio_output_callback_(audio_stream_info.bytes_to_frames(bytes_written),
-                                               esp_timer_get_time() + dma_buffer_duration_ms * 1000);
-        }
-#endif
       }
 
       // Process timestamp events and update last_dma_write_
       int64_t write_timestamp = esp_timer_get_time();
-#ifndef USE_I2S_LEGACY
       // Process timestamp events from I2S on_sent callback
       while (xQueueReceive(this_speaker->i2s_sent_time_queue_, &write_timestamp, 0)) {
         // For each timestamp event, calculate frames sent and call audio_output_callback_
@@ -501,7 +479,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
           this_speaker->audio_output_callback_(frames_sent, write_timestamp);
         }
       }
-#endif
 
       if (xSemaphoreTake(this_speaker->lock_, pdMS_TO_TICKS(10))) {
         this_speaker->in_write_buffer_ = 0;
@@ -519,12 +496,10 @@ void I2SAudioSpeaker::speaker_task(void *params) {
     xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_STOPPING);
 
     // stop_i2s_channel_() is called by loop() when handling STATE_STOPPED
-#ifndef USE_I2S_LEGACY
     if (scaling_buffer != nullptr) {
       // Deallocate the scaling buffer if it was allocated
       delete[] scaling_buffer;
     }
-#endif
   }
   this_speaker->delete_task_(read_buffer_size);
 }
@@ -644,7 +619,6 @@ esp_err_t I2SAudioSpeaker::allocate_buffers_(size_t data_buffer_size, size_t rin
   return ESP_OK;
 }
 
-#ifndef USE_I2S_LEGACY
 bool IRAM_ATTR I2SAudioSpeaker::i2s_on_sent_cb(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
   int64_t now = esp_timer_get_time();
 
@@ -664,7 +638,6 @@ bool IRAM_ATTR I2SAudioSpeaker::i2s_on_sent_cb(i2s_chan_handle_t handle, i2s_eve
 
   return need_yield1 | need_yield2 | need_yield3;
 }
-#endif
 
 esp_err_t I2SAudioSpeaker::start_i2s_driver_(audio::AudioStreamInfo &audio_stream_info) {
   if (this->has_fixed_i2s_rate() && (this->sample_rate_ != audio_stream_info.get_sample_rate())) {  // NOLINT
@@ -676,18 +649,12 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_(audio::AudioStreamInfo &audio_strea
     // Can't reconfigure I2S bus, and bit depth must match the configured value
     return ESP_ERR_NOT_SUPPORTED;
   }
-#if USE_I2S_LEGACY
-  if (!this->start_i2s_channel_()) {
-    return ESP_ERR_INVALID_STATE;
-  }
-#else
   const i2s_event_callbacks_t callbacks = {
       .on_sent = i2s_on_sent_cb,
   };
   if (!this->start_i2s_channel_(callbacks)) {
     return ESP_ERR_INVALID_STATE;
   }
-#endif
   return ESP_OK;
 }
 

--- a/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -120,14 +120,12 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   /// @param buffer_size The allocated size of the data_buffer_.
   void delete_task_(size_t buffer_size);
 
-#ifndef USE_I2S_LEGACY
   /// @brief Callback function used to send playback timestamps the to the speaker task.
   /// @param handle (i2s_chan_handle_t)
   /// @param event (i2s_event_data_t)
   /// @param user_ctx (void*) User context pointer that the callback accesses
   /// @return True if a higher priority task was interrupted
   static bool IRAM_ATTR i2s_on_sent_cb(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx);
-#endif
 
   TaskHandle_t speaker_task_handle_{nullptr};
   EventGroupHandle_t event_group_{nullptr};

--- a/components/resampler/speaker/__init__.py
+++ b/components/resampler/speaker/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import audio, esp32, socket, speaker
+from esphome.components import audio, esp32, speaker
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BITS_PER_SAMPLE,
@@ -77,9 +77,6 @@ FINAL_VALIDATE_SCHEMA = _validate_audio_compatibility
 
 
 async def to_code(config):
-    # Enable wake_loop_threadsafe for immediate command processing from other tasks
-    socket.require_wake_loop_threadsafe()
-
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await speaker.register_speaker(var, config)

--- a/components/resampler/speaker/resampler_speaker.cpp
+++ b/components/resampler/speaker/resampler_speaker.cpp
@@ -245,11 +245,9 @@ void ResamplerSpeaker::send_command_(uint32_t command_bit, bool wake_loop) {
   uint32_t event_bits = xEventGroupGetBits(this->event_group_);
   if (!(event_bits & command_bit)) {
     xEventGroupSetBits(this->event_group_, command_bit);
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
     if (wake_loop) {
       App.wake_loop_threadsafe();
     }
-#endif
   }
 }
 
@@ -317,57 +315,59 @@ void ResamplerSpeaker::resample_task(void *params) {
 
   xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::STATE_STARTING);
 
-  std::unique_ptr<audio::AudioResampler> resampler =
-      make_unique<audio::AudioResampler>(this_resampler->audio_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS),
-                                         this_resampler->target_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
+  {  // Ensure C++ objects fall out of scope for proper cleanup before stopping the task
+    std::unique_ptr<audio::AudioResampler> resampler = make_unique<audio::AudioResampler>(
+        this_resampler->audio_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS),
+        this_resampler->target_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
 
-  esp_err_t err = resampler->start(this_resampler->audio_stream_info_, this_resampler->target_stream_info_,
-                                   this_resampler->taps_, this_resampler->filters_);
+    esp_err_t err = resampler->start(this_resampler->audio_stream_info_, this_resampler->target_stream_info_,
+                                     this_resampler->taps_, this_resampler->filters_);
 
-  if (err == ESP_OK) {
-    std::shared_ptr<RingBuffer> temp_ring_buffer =
-        RingBuffer::create(this_resampler->audio_stream_info_.ms_to_bytes(this_resampler->buffer_duration_ms_));
+    if (err == ESP_OK) {
+      std::shared_ptr<RingBuffer> temp_ring_buffer =
+          RingBuffer::create(this_resampler->audio_stream_info_.ms_to_bytes(this_resampler->buffer_duration_ms_));
 
-    if (!temp_ring_buffer) {
-      err = ESP_ERR_NO_MEM;
-    } else {
-      this_resampler->ring_buffer_ = temp_ring_buffer;
-      resampler->add_source(this_resampler->ring_buffer_);
+      if (!temp_ring_buffer) {
+        err = ESP_ERR_NO_MEM;
+      } else {
+        this_resampler->ring_buffer_ = temp_ring_buffer;
+        resampler->add_source(this_resampler->ring_buffer_);
 
-      this_resampler->output_speaker_->set_audio_stream_info(this_resampler->target_stream_info_);
-      resampler->add_sink(this_resampler->output_speaker_);
-    }
-  }
-
-  if (err == ESP_OK) {
-    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::STATE_RUNNING);
-  } else if (err == ESP_ERR_NO_MEM) {
-    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_NO_MEM);
-  } else if (err == ESP_ERR_NOT_SUPPORTED) {
-    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_NOT_SUPPORTED);
-  }
-
-  while (err == ESP_OK) {
-    uint32_t event_bits = xEventGroupGetBits(this_resampler->event_group_);
-
-    if (event_bits & ResamplingEventGroupBits::TASK_COMMAND_STOP) {
-      break;
+        this_resampler->output_speaker_->set_audio_stream_info(this_resampler->target_stream_info_);
+        resampler->add_sink(this_resampler->output_speaker_);
+      }
     }
 
-    // Stop gracefully if the decoder is done
-    int32_t ms_differential = 0;
-    audio::AudioResamplerState resampler_state = resampler->resample(false, &ms_differential);
-
-    if (resampler_state == audio::AudioResamplerState::FINISHED) {
-      break;
-    } else if (resampler_state == audio::AudioResamplerState::FAILED) {
-      xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_FAIL);
-      break;
+    if (err == ESP_OK) {
+      xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::STATE_RUNNING);
+    } else if (err == ESP_ERR_NO_MEM) {
+      xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_NO_MEM);
+    } else if (err == ESP_ERR_NOT_SUPPORTED) {
+      xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_NOT_SUPPORTED);
     }
+
+    while (err == ESP_OK) {
+      uint32_t event_bits = xEventGroupGetBits(this_resampler->event_group_);
+
+      if (event_bits & ResamplingEventGroupBits::TASK_COMMAND_STOP) {
+        break;
+      }
+
+      // Stop gracefully if the decoder is done
+      int32_t ms_differential = 0;
+      audio::AudioResamplerState resampler_state = resampler->resample(false, &ms_differential);
+
+      if (resampler_state == audio::AudioResamplerState::FINISHED) {
+        break;
+      } else if (resampler_state == audio::AudioResamplerState::FAILED) {
+        xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_FAIL);
+        break;
+      }
+    }
+
+    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::STATE_STOPPING);
   }
 
-  xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::STATE_STOPPING);
-  resampler.reset();
   xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::STATE_STOPPED);
 
   vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it

--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -50,9 +50,7 @@ i2s_audio:
     i2s_lrclk_pin: GPIO07
     i2s_bclk_pin: GPIO08
     i2s_mclk_pin: GPIO16
-    access_mode: duplex
     i2s_mode: secondary
-    use_legacy: false
 
 sensor:
   - platform: wifi_signal

--- a/config/common/core_board.yaml
+++ b/config/common/core_board.yaml
@@ -6,6 +6,10 @@ esp32:
   framework:
     type: esp-idf
     version: recommended
+    components:
+      # Pin esp-nn to 1.1.2 to avoid TFLite tensor arena size regression in 1.2.1
+      # esp-tflite-micro requires ^1.1.0 (any 1.x), but 1.2.1 needs larger arenas
+      - espressif/esp-nn==1.1.2
     sdkconfig_options:
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2026.3.2
+esphome==2026.4.0b1
 setuptools

--- a/scripts/setup_build_env.sh
+++ b/scripts/setup_build_env.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
-set -e
+# #!/bin/bash
+# set -e
 
 # Configuration
 PYTHON_MIN_VERSION="3.11"
-PYTHON_MAX_VERSION="3.14"
+PYTHON_MAX_VERSION="3.15"
 VENV_DIR=".venv"
 
 # Get script directory to find requirements.txt
@@ -20,7 +20,7 @@ fi
 if [[ ! -f "$SCRIPT_DIR/setup_build_env.sh" ]]; then
     # Fallback: assume we're in the project root or use git to find it
     if [[ -f "scripts/setup_build_env.sh" ]]; then
-        SCRIPT_DIR="$(pwd)/scripts"
+        SCRIPT_DIR="$(pwd)/scripts" 
     elif command -v git &> /dev/null && git rev-parse --show-toplevel &> /dev/null; then
         SCRIPT_DIR="$(git rev-parse --show-toplevel)/scripts"
     fi


### PR DESCRIPTION
## Summary

- Bump ESPHome from `2026.3.2` to `2026.4.0`
- Allow Python 3.14 in the build environment
- Sync `i2s_audio` component with ESPHome 2026.4: removes legacy I2S driver support (`USE_I2S_LEGACY`), cleans up deprecated config options (`access_mode`, `bits_per_channel`, `use_legacy`), and switches fully to the new I2S driver
- Sync `resampler` speaker component with ESPHome 2026.4 upstream changes
- Pin `espressif/esp-nn` to `1.1.2` to avoid a TFLite tensor arena size regression introduced in `1.2.1`