### PR TITLE
Apply coding style fixes to memory_flasher and satellite1 components

### DIFF
--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -125,7 +125,7 @@ memory_flasher:
 
     on_progress_update:
       then:
-        - lambda: id(global_led_animation_index) = id(xflash).flashing_progress * 24 / 100;
+        - lambda: id(global_led_animation_index) = id(xflash).get_flashing_progress() * 24 / 100;
         - script.execute: control_leds
 
     on_flashing_success:

--- a/config/satellite1.yaml
+++ b/config/satellite1.yaml
@@ -48,7 +48,7 @@ packages:
               condition:
                 - lambda: return id(init_in_progress);
                 - lambda: return id(xflash).has_image_embedded();
-                - lambda: return !id(xflash).match_embedded( id(satellite1_id).xmos_fw_version );
+                - lambda: return !id(xflash).match_embedded( id(satellite1_id).get_xmos_fw_version() );
               then:
                 - memory_flasher.write_embedded_image:
 

--- a/esphome/components/memory_flasher/automation.h
+++ b/esphome/components/memory_flasher/automation.h
@@ -8,7 +8,7 @@ namespace memory_flasher {
 
 template<typename... Ts> class FlashAction : public Action<Ts...> {
  public:
-  FlashAction(MemoryFlasher *parent) : parent_(parent) {}
+  explicit FlashAction(MemoryFlasher *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(std::string, md5_url)
   TEMPLATABLE_VALUE(std::string, md5)
   TEMPLATABLE_VALUE(std::string, url)
@@ -43,7 +43,7 @@ template<FlasherState State> class FlasherStateTrigger : public Trigger<> {
  public:
   explicit FlasherStateTrigger(MemoryFlasher *xflash) {
     xflash->add_on_state_callback([this, xflash]() {
-      if (xflash->state == State)
+      if (xflash->get_state() == State)
         this->trigger();
     });
   }
@@ -53,11 +53,11 @@ class FlashingStartedTrigger : public Trigger<> {
  public:
   explicit FlashingStartedTrigger(MemoryFlasher *xflash) {
     xflash->add_on_state_callback([this, xflash]() {
-      if (xflash->state == FLASHER_ERASING && this->last_reported_ != FLASHER_ERASING) {
+      if (xflash->get_state() == FLASHER_ERASING && this->last_reported_ != FLASHER_ERASING) {
         this->last_reported_ = FLASHER_ERASING;
         this->trigger();
       } else {
-        this->last_reported_ = xflash->state;
+        this->last_reported_ = xflash->get_state();
       }
     });
   }
@@ -70,7 +70,7 @@ class ErasingDoneTrigger : public Trigger<> {
  public:
   explicit ErasingDoneTrigger(MemoryFlasher *xflash) {
     xflash->add_on_state_callback([this, xflash]() {
-      if (xflash->state == FLASHER_SUCCESS_STATE && xflash->requested_action == ACTION_FULL_ERASE) {
+      if (xflash->get_state() == FLASHER_SUCCESS_STATE && xflash->get_requested_action() == ACTION_FULL_ERASE) {
         this->trigger();
       }
     });
@@ -81,9 +81,10 @@ class FlashingProgressUpdateTrigger : public Trigger<> {
  public:
   explicit FlashingProgressUpdateTrigger(MemoryFlasher *xflash) {
     xflash->add_on_state_callback([this, xflash]() {
-      if (xflash->state == FLASHER_FLASHING && xflash->flashing_progress != this->last_reported_)
-        this->last_reported_ = xflash->flashing_progress;
-      this->trigger();
+      if (xflash->get_state() == FLASHER_FLASHING && xflash->get_flashing_progress() != this->last_reported_) {
+        this->last_reported_ = xflash->get_flashing_progress();
+        this->trigger();
+      }
     });
   }
 
@@ -96,7 +97,7 @@ using FlasherFailedTrigger = FlasherStateTrigger<FLASHER_ERROR_STATE>;
 
 template<typename... Ts> class InProgressCondition : public Condition<Ts...>, public Parented<MemoryFlasher> {
  public:
-  bool check(Ts... x) override { return this->parent_->state != FLASHER_IDLE; }
+  bool check(Ts... x) override { return this->parent_->get_state() != FLASHER_IDLE; }
 };
 
 }  // namespace memory_flasher

--- a/esphome/components/memory_flasher/memory_flasher.cpp
+++ b/esphome/components/memory_flasher/memory_flasher.cpp
@@ -98,8 +98,8 @@ bool HttpImageReader::deinit_reader() {
 
 int HttpImageReader::read_image_block(uint8_t *buffer, size_t block_size) {
   int bytes_read = this->container_->read(buffer, block_size);
-  ESP_LOGVV(TAG, "bytes_read_ = %u, body_length_ = %u, bufsize = %i", container->get_bytes_read(),
-            container->content_length, bytes_read);
+  ESP_LOGVV(TAG, "bytes_read_ = %u, body_length_ = %u, bufsize = %i", this->container_->get_bytes_read(),
+            this->container_->content_length, bytes_read);
   return bytes_read;
 }
 

--- a/esphome/components/memory_flasher/memory_flasher.h
+++ b/esphome/components/memory_flasher/memory_flasher.h
@@ -113,10 +113,10 @@ enum FlasherState : uint8_t {
 
 class MemoryFlasher : public Component {
  public:
-  uint8_t flashing_progress{0};
-  FlasherState state{FLASHER_IDLE};
-  FlasherError error_code{FLASHER_OK};
-  FlasherAction requested_action;
+  FlasherState get_state() const { return this->state_; }
+  FlasherError get_error_code() const { return this->error_code_; }
+  FlasherAction get_requested_action() const { return this->requested_action_; }
+  uint8_t get_flashing_progress() const { return this->flashing_progress_; }
 
   virtual void dump_config() override;
 
@@ -131,7 +131,7 @@ class MemoryFlasher : public Component {
   virtual bool flash_accessible() { return false; }
   bool has_image_embedded() { return this->embedded_image_.length > 0; }
 
-  bool match_embedded(uint8_t to_compare[5]) { return memcmp(this->embedded_image_.version.bytes, to_compare, 5) == 0; }
+  bool match_embedded(const uint8_t *to_compare) { return memcmp(this->embedded_image_.version.bytes, to_compare, 5) == 0; }
 
   void set_embedded_image(const uint8_t *pgm_pointer, size_t length, std::string expected_md5,
                           const char version_bytes[5]) {
@@ -149,7 +149,7 @@ class MemoryFlasher : public Component {
   void set_md5(const std::string &md5) { this->md5_expected_ = md5; }
   void set_url(const std::string &url);
 
-  void add_on_state_callback(std::function<void()> &&callback) { this->state_callback_.add(std::move(callback)); }
+  template<typename F> void add_on_state_callback(F &&callback) { this->state_callback_.add(std::forward<F>(callback)); }
   void publish() {
     // this->defer([this]() { this->state_callback_.call(); });
     this->state_callback_.call();
@@ -158,6 +158,11 @@ class MemoryFlasher : public Component {
  protected:
   virtual void publish_progress_() {}
   CallbackManager<void()> state_callback_{};
+
+  uint8_t flashing_progress_{0};
+  FlasherState state_{FLASHER_IDLE};
+  FlasherError error_code_{FLASHER_OK};
+  FlasherAction requested_action_{};
 
   /* flashing embedded image*/
   FlashImage embedded_image_;

--- a/esphome/components/satellite1/automation.h
+++ b/esphome/components/satellite1/automation.h
@@ -15,7 +15,7 @@ template<Satellite1State State> class Satellite1StateTrigger : public Trigger<> 
  public:
   explicit Satellite1StateTrigger(Satellite1 *sat1) {
     sat1->add_on_state_callback([this, sat1]() {
-      if (sat1->state == State)
+      if (sat1->get_state() == State)
         this->trigger();
     });
   }
@@ -28,7 +28,7 @@ class XMOSNoResponseStateTrigger : public Trigger<> {
  public:
   explicit XMOSNoResponseStateTrigger(Satellite1 *sat1) {
     sat1->add_on_state_callback([this, sat1]() {
-      if (sat1->state == SAT_DETACHED_STATE && sat1->connection_attempts == MAX_CONNECTION_ATTEMPTS)
+      if (sat1->get_state() == SAT_DETACHED_STATE && sat1->get_connection_attempts() == MAX_CONNECTION_ATTEMPTS)
         this->trigger();
     });
   }

--- a/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
+++ b/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
@@ -4,6 +4,7 @@
 #include <endian.h>
 
 namespace esphome {
+using namespace memory_flasher;
 namespace satellite1 {
 
 static const char *const TAG = "xmos_flasher";
@@ -13,29 +14,29 @@ static const size_t FLASH_SECTOR_SIZE = 4096;
 constexpr size_t FLASH_TOTAL_NUMBER_OF_SECTORS = 8388608 / FLASH_SECTOR_SIZE;
 
 void XMOSFlasher::loop() {
-  switch (this->state) {
+  switch (this->state_) {
     case FLASHER_IDLE:
       break;
 
     case FLASHER_INITIALIZING:
       if (this->init_flashing_()) {
-        this->state = FLASHER_ERASING;
+        this->state_ = FLASHER_ERASING;
       } else {
         this->deinit_flashing_();
-        this->state = FLASHER_ERROR_STATE;
+        this->state_ = FLASHER_ERROR_STATE;
       }
       break;
 
     case FLASHER_ERASING: {
       int remaining = this->erasing_step_();
       this->publish_progress_();
-      if (remaining == 0 && this->requested_action == ACTION_FULL_ERASE) {
+      if (remaining == 0 && this->requested_action_ == ACTION_FULL_ERASE) {
         this->deinit_flashing_();
-        this->state = FLASHER_SUCCESS_STATE;
+        this->state_ = FLASHER_SUCCESS_STATE;
       } else if (remaining == 0) {
-        this->state = FLASHER_FLASHING;
+        this->state_ = FLASHER_FLASHING;
       } else if (remaining < 0) {
-        this->state = FLASHER_ERROR_STATE;
+        this->state_ = FLASHER_ERROR_STATE;
       }
       break;
     }
@@ -45,22 +46,22 @@ void XMOSFlasher::loop() {
       this->publish_progress_();
       if (remaining == 0) {
         this->deinit_flashing_();
-        this->state = FLASHER_SUCCESS_STATE;
+        this->state_ = FLASHER_SUCCESS_STATE;
       } else if (remaining < 0) {
         this->deinit_flashing_();
-        this->state = FLASHER_ERROR_STATE;
+        this->state_ = FLASHER_ERROR_STATE;
       }
       break;
     }
 
     case FLASHER_SUCCESS_STATE:
       this->publish();
-      this->state = FLASHER_IDLE;
+      this->state_ = FLASHER_IDLE;
       break;
 
     case FLASHER_ERROR_STATE:
       this->publish();
-      this->state = FLASHER_IDLE;
+      this->state_ = FLASHER_IDLE;
       break;
 
     default:
@@ -72,14 +73,14 @@ void XMOSFlasher::publish_progress_() {
   uint32_t now = millis();
 
   if ((now - this->last_published_) > 1000) {
-    if (this->requested_action == ACTION_FULL_ERASE) {
-      this->flashing_progress = this->current_sector_ * 100 / this->total_sectors_to_erase_;
+    if (this->requested_action_ == ACTION_FULL_ERASE) {
+      this->flashing_progress_ = this->current_sector_ * 100 / this->total_sectors_to_erase_;
     } else {
-      this->flashing_progress = ((this->current_sector_ + this->total_number_of_bytes_ - this->bytes_remaining_) * 100 /
+      this->flashing_progress_ = ((this->current_sector_ + this->total_number_of_bytes_ - this->bytes_remaining_) * 100 /
                                  (this->total_number_of_bytes_ + this->total_sectors_to_erase_));
     }
     this->last_published_ = now;
-    ESP_LOGD(TAG, "Progress: %d%%", this->flashing_progress);
+    ESP_LOGD(TAG, "Progress: %d%%", this->flashing_progress_);
     this->publish();
   }
 }
@@ -87,7 +88,7 @@ void XMOSFlasher::publish_progress_() {
 bool XMOSFlasher::init_flasher() {
   ESP_LOGD(TAG, "Setting up XMOS flasher...");
   this->parent_->set_spi_flash_direct_access_mode(true);
-  this->read_JEDECID_();
+  this->read_jedec_id_();
   this->dump_flash_info();
   this->total_number_of_sectors_ = FLASH_TOTAL_NUMBER_OF_SECTORS;
   return true;
@@ -101,66 +102,65 @@ bool XMOSFlasher::deinit_flasher() {
 
 void XMOSFlasher::dump_flash_info() {
   ESP_LOGCONFIG(TAG, "Satellite1-Flasher:");
-  ESP_LOGCONFIG(TAG, "	JEDEC-manufacturerID %hhu", this->manufacturerID_);
-  ESP_LOGCONFIG(TAG, "	JEDEC-memoryTypeID %hhu", this->memoryTypeID_);
-  ESP_LOGCONFIG(TAG, "	JEDEC-capacityID %hhu", this->capacityID_);
-  ESP_LOGCONFIG(TAG, "	JEDEC-capacityID %hhu", this->capacityID_);
-  ESP_LOGCONFIG(TAG, "	JEDEC-capacity: %hhu", 1 << this->capacityID_);
+  ESP_LOGCONFIG(TAG, "  JEDEC-manufacturer_id %hhu", this->manufacturer_id_);
+  ESP_LOGCONFIG(TAG, "  JEDEC-memory_type_id %hhu", this->memory_type_id_);
+  ESP_LOGCONFIG(TAG, "  JEDEC-capacity_id %hhu", this->capacity_id_);
+  ESP_LOGCONFIG(TAG, "  JEDEC-capacity: %hhu", 1 << this->capacity_id_);
 }
 
 void XMOSFlasher::erase_memory() {
-  if (this->state != FLASHER_IDLE) {
+  if (this->state_ != FLASHER_IDLE) {
     ESP_LOGE(TAG, "XMOS flasher is busy, can't inititate erasing");
     return;
   }
 
-  this->requested_action = ACTION_FULL_ERASE;
-  this->state = FLASHER_INITIALIZING;
+  this->requested_action_ = ACTION_FULL_ERASE;
+  this->state_ = FLASHER_INITIALIZING;
 }
 
 void XMOSFlasher::flash_remote_image() {
-  if (this->state != FLASHER_IDLE) {
+  if (this->state_ != FLASHER_IDLE) {
     ESP_LOGE(TAG, "XMOS flasher is busy, can't initiate new flash");
     return;
   }
 
   if (this->url_.empty()) {
     ESP_LOGE(TAG, "URL not set; cannot start flashing");
-    this->error_code = BAD_URL;
-    this->state = FLASHER_ERROR_STATE;
+    this->error_code_ = BAD_URL;
+    this->state_ = FLASHER_ERROR_STATE;
     return;
   }
 
   if (this->md5_expected_.empty() && !this->http_get_md5_()) {
     ESP_LOGE(TAG, "Couldn't receive expected md5 sum.");
-    this->error_code = MD5_INVALID;
-    this->state = FLASHER_ERROR_STATE;
+    this->error_code_ = MD5_INVALID;
+    this->state_ = FLASHER_ERROR_STATE;
     return;
   }
 
-  this->requested_action = ACTION_FLASH_REMOTE_IMAGE;
-  this->state = FLASHER_INITIALIZING;
+  this->requested_action_ = ACTION_FLASH_REMOTE_IMAGE;
+  this->state_ = FLASHER_INITIALIZING;
 }
 
 void XMOSFlasher::flash_embedded_image() {
-  if (this->state != FLASHER_IDLE) {
+  if (this->state_ != FLASHER_IDLE) {
     ESP_LOGE(TAG, "XMOS flasher is busy, can't inititate new flash");
     return;
   }
 
   if (this->embedded_image_.length == 0) {
     ESP_LOGE(TAG, "Didn't find embedded image!");
-    this->error_code = NO_EMBEDDED_IMAGE_ERROR;
-    this->state = FLASHER_ERROR_STATE;
+    this->error_code_ = NO_EMBEDDED_IMAGE_ERROR;
+    this->state_ = FLASHER_ERROR_STATE;
     return;
   }
 
   this->md5_expected_ = this->embedded_image_.md5;
-  this->requested_action = ACTION_FLASH_EMBEDDED_IMAGE;
-  this->state = FLASHER_INITIALIZING;
+  this->requested_action_ = ACTION_FLASH_EMBEDDED_IMAGE;
+  this->state_ = FLASHER_INITIALIZING;
 }
 
-bool XMOSFlasher::read_JEDECID_() {
+bool XMOSFlasher::read_jedec_id_() {
   uint8_t manufacturer = 0;
   uint8_t memoryType = 0;
   uint8_t capcacity = 0;
@@ -172,9 +172,9 @@ bool XMOSFlasher::read_JEDECID_() {
   this->disable();
 
   if (manufacturer && memoryType && capcacity) {
-    this->manufacturerID_ = manufacturer;
-    this->memoryTypeID_ = memoryType;
-    this->capacityID_ = capcacity;
+    this->manufacturer_id_ = manufacturer;
+    this->memory_type_id_ = memoryType;
+    this->capacity_id_ = capcacity;
     return true;
   }
   return false;
@@ -307,13 +307,13 @@ bool XMOSFlasher::read_page_(uint32_t byte_addr, uint8_t *buffer) {
 
 bool XMOSFlasher::init_flashing_() {
   if (!this->init_flasher()) {
-    this->error_code = INIT_FLASH_ERROR;
+    this->error_code_ = INIT_FLASH_ERROR;
     return false;
   }
 
   this->flashing_start_time_ = millis();
 
-  switch (this->requested_action) {
+  switch (this->requested_action_) {
     case ACTION_FLASH_EMBEDDED_IMAGE:
       this->reader_ = new EmbeddedImageReader(this->embedded_image_);
       break;
@@ -327,27 +327,27 @@ bool XMOSFlasher::init_flashing_() {
   };
 
   if (!this->reader_->init_reader()) {
-    this->error_code = INIT_READER_ERROR;
+    this->error_code_ = INIT_READER_ERROR;
     return false;
   }
 
   this->reader_buffer_ = (uint8_t *) malloc(FLASH_PAGE_SIZE);
   if (this->reader_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Couldn't allocate memory");
-    this->error_code = INIT_FLASH_ERROR;
+    this->error_code_ = INIT_FLASH_ERROR;
     return false;
   }
 
   this->compare_buffer_ = (uint8_t *) malloc(FLASH_PAGE_SIZE);
   if (this->compare_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Couldn't allocate memory");
-    this->error_code = INIT_FLASH_ERROR;
+    this->error_code_ = INIT_FLASH_ERROR;
     return false;
   }
 
   ESP_LOGD(TAG, "MD5 expected: %s", this->md5_expected_.c_str());
 
-  this->flashing_progress = 0;
+  this->flashing_progress_ = 0;
   this->md5_receive_.init();
 
   size_t size_in_bytes = this->reader_->get_image_size();
@@ -396,7 +396,7 @@ int XMOSFlasher::erasing_step_() {
   this->current_sector_++;
   if (this->current_sector_ < this->total_sectors_to_erase_) {
     if (!this->erase_sector_(this->current_sector_)) {
-      this->error_code = WRITE_TO_FLASH_ERROR;
+      this->error_code_ = WRITE_TO_FLASH_ERROR;
       return -1;
     }
   }
@@ -409,7 +409,7 @@ int XMOSFlasher::flashing_step_() {
   int bytes_read = this->reader_->read_image_block(this->reader_buffer_, FLASH_PAGE_SIZE);
   if (bytes_read < 0) {
     ESP_LOGE(TAG, "Stream closed");
-    this->error_code = CONNECTION_ERROR;
+    this->error_code_ = CONNECTION_ERROR;
     return -1;
   }
 
@@ -417,7 +417,7 @@ int XMOSFlasher::flashing_step_() {
   this->bytes_remaining_ -= bytes_read;
   if (bytes_read != FLASH_PAGE_SIZE) {
     if (this->bytes_remaining_ != 0) {
-      this->error_code = CONNECTION_ERROR;
+      this->error_code_ = CONNECTION_ERROR;
       return -1;
     }
     // it's the last page to flash
@@ -437,14 +437,14 @@ int XMOSFlasher::flashing_step_() {
     // not equal, give it a second try
     if (!this->write_page_(page_pos, this->reader_buffer_)) {
       ESP_LOGE(TAG, "Error while writing page %d, giving up...", page_pos);
-      this->error_code = WRITE_TO_FLASH_ERROR;
+      this->error_code_ = WRITE_TO_FLASH_ERROR;
       return -1;
     }
 
     this->read_page_(page_pos, this->compare_buffer_);
     if (memcmp(this->reader_buffer_, this->compare_buffer_, FLASH_PAGE_SIZE) != 0) {
       ESP_LOGE(TAG, "Read page mismatch, page addr: %d", page_pos);
-      this->error_code = WRITE_TO_FLASH_ERROR;
+      this->error_code_ = WRITE_TO_FLASH_ERROR;
       return -1;
     }
   }
@@ -459,7 +459,7 @@ int XMOSFlasher::flashing_step_() {
 
     if (strncmp(this->md5_computed_.c_str(), this->md5_expected_.c_str(), MD5_SIZE) != 0) {
       ESP_LOGE(TAG, "MD5 computed: %s - Aborting due to MD5 mismatch", this->md5_computed_.c_str());
-      this->error_code = MD5_MISMATCH_ERROR;
+      this->error_code_ = MD5_MISMATCH_ERROR;
       return -1;
     } else {
       ESP_LOGD(TAG, "MD5 computed: %s - Matches!", this->md5_computed_.c_str());

--- a/esphome/components/satellite1/memory_flasher/xmos_flashing.h
+++ b/esphome/components/satellite1/memory_flasher/xmos_flashing.h
@@ -9,10 +9,9 @@
 #include "esphome/components/satellite1/satellite1.h"
 
 namespace esphome {
-using namespace memory_flasher;
 namespace satellite1 {
 
-class XMOSFlasher : public MemoryFlasher, public Satellite1SPIService {
+class XMOSFlasher : public memory_flasher::MemoryFlasher, public Satellite1SPIService {
  public:
   void loop() override;
 
@@ -26,13 +25,13 @@ class XMOSFlasher : public MemoryFlasher, public Satellite1SPIService {
 
   bool flash_accessible() override {
     this->parent_->set_spi_flash_direct_access_mode(true);
-    bool got_id = this->read_JEDECID_();
+    bool got_id = this->read_jedec_id_();
     this->parent_->set_spi_flash_direct_access_mode(false);
     return got_id;
   }
 
  protected:
-  bool read_JEDECID_();
+  bool read_jedec_id_();
   bool enable_writing_();
   bool disable_writing_();
   bool chip_erase_();
@@ -41,9 +40,9 @@ class XMOSFlasher : public MemoryFlasher, public Satellite1SPIService {
   bool read_page_(uint32_t byte_addr, uint8_t *buffer);
   bool write_page_(uint32_t byte_addr, uint8_t *buffer);
 
-  uint8_t manufacturerID_;
-  uint8_t memoryTypeID_;
-  uint8_t capacityID_;
+  uint8_t manufacturer_id_;
+  uint8_t memory_type_id_;
+  uint8_t capacity_id_;
   int32_t capacity_;
   size_t total_number_of_sectors_;
 
@@ -55,7 +54,7 @@ class XMOSFlasher : public MemoryFlasher, public Satellite1SPIService {
 
   bool http_flash_{false};
   bool embedded_flash_{false};
-  FlashImageReader *reader_;
+  memory_flasher::FlashImageReader *reader_;
   md5::MD5Digest md5_receive_;
 
   uint32_t flashing_start_time_{0};

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace satellite1 {
 
-static const char *TAG = "Satellite1";
+static const char *const TAG = "Satellite1";
 
 void Satellite1::setup() {
   this->spi_setup();
@@ -17,7 +17,7 @@ void Satellite1::setup() {
     this->xmos_rst_pin_->setup();
   }
 
-  memset(this->xmos_fw_version, 0, 5);
+  memset(this->xmos_fw_version_, 0, 5);
   this->dfu_get_fw_version_();
 }
 
@@ -33,18 +33,18 @@ void Satellite1::dump_config() {
 }
 
 void Satellite1::loop() {
-  switch (this->state) {
+  switch (this->state_) {
     case SAT_DETACHED_STATE:
-      if (this->connection_attempts <= MAX_CONNECTION_ATTEMPTS && (millis() - this->last_attempt_timestamp_) > 1000) {
-        if (this->connection_attempts == MAX_CONNECTION_ATTEMPTS) {
+      if (this->connection_attempts_ <= MAX_CONNECTION_ATTEMPTS && (millis() - this->last_attempt_timestamp_) > 1000) {
+        if (this->connection_attempts_ == MAX_CONNECTION_ATTEMPTS) {
           this->state_callback_.call();
         } else if (this->check_for_xmos_()) {
-          this->state = SAT_XMOS_CONNECTED_STATE;
-          this->connection_attempts = 0;
+          this->state_ = SAT_XMOS_CONNECTED_STATE;
+          this->connection_attempts_ = 0;
           this->state_callback_.call();
         }
         this->last_attempt_timestamp_ = millis();
-        this->connection_attempts++;
+        this->connection_attempts_++;
       }
       break;
     case SAT_XMOS_CONNECTED_STATE:
@@ -70,15 +70,15 @@ static std::string prerelease_str(uint8_t pre_idx) {
 }
 
 std::string Satellite1::status_string() {
-  switch (this->state) {
+  switch (this->state_) {
     case SAT_DETACHED_STATE:
       return "XMOS not responding";
 
     case SAT_XMOS_CONNECTED_STATE:
-      return ("v" + std::to_string(this->xmos_fw_version[0]) + "." + std::to_string(this->xmos_fw_version[1]) + "." +
-              std::to_string(this->xmos_fw_version[2]) +
-              (this->xmos_fw_version[3] ? "-" + prerelease_str(this->xmos_fw_version[3]) : "") +
-              (this->xmos_fw_version[4] ? "." + std::to_string(this->xmos_fw_version[4]) : ""));
+      return ("v" + std::to_string(this->xmos_fw_version_[0]) + "." + std::to_string(this->xmos_fw_version_[1]) + "." +
+              std::to_string(this->xmos_fw_version_[2]) +
+              (this->xmos_fw_version_[3] ? "-" + prerelease_str(this->xmos_fw_version_[3]) : "") +
+              (this->xmos_fw_version_[4] ? "." + std::to_string(this->xmos_fw_version_[4]) : ""));
     case SAT_FLASH_CONNECTED_STATE:
       return "Flashing Mode";
     default:
@@ -87,7 +87,7 @@ std::string Satellite1::status_string() {
 }
 
 bool Satellite1::request_status_register_update() {
-  bool ret = this->transfer(0, 0, NULL, 0);
+  bool ret = this->transfer(0, 0, nullptr, 0);
   return ret;
 }
 
@@ -151,10 +151,10 @@ bool Satellite1::transfer(uint8_t resource_id, uint8_t command, uint8_t *payload
 void Satellite1::set_spi_flash_direct_access_mode(bool enable) {
   this->xmos_rst_pin_->digital_write(enable);
   if (enable) {
-    this->state = SAT_FLASH_CONNECTED_STATE;
+    this->state_ = SAT_FLASH_CONNECTED_STATE;
   } else if (this->spi_flash_direct_access_enabled_) {
-    this->state = SAT_DETACHED_STATE;
-    this->connection_attempts = 0;
+    this->state_ = SAT_DETACHED_STATE;
+    this->connection_attempts_ = 0;
   }
   this->spi_flash_direct_access_enabled_ = enable;
   this->state_callback_.call();
@@ -167,7 +167,7 @@ bool Satellite1::dfu_get_fw_version_() {
     return false;
   }
 
-  memcpy(this->xmos_fw_version, version_resp, 5);
+  memcpy(this->xmos_fw_version_, version_resp, 5);
   ESP_LOGI(TAG, "XMOS Firmware Version: %s ", this->status_string().c_str());
 
   return true;
@@ -178,7 +178,7 @@ bool Satellite1::check_for_xmos_() {
     return false;
   }
   const uint8_t compare_zeros[5] = {0};
-  return (memcmp(this->xmos_fw_version, compare_zeros, 5) != 0);
+  return (memcmp(this->xmos_fw_version_, compare_zeros, 5) != 0);
 }
 
 void Satellite1::xmos_hardware_reset() {

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -63,10 +63,11 @@ class Satellite1 : public Component,
                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                          spi::DATA_RATE_1KHZ> {
  public:
-  Satellite1State state{SAT_DETACHED_STATE};
-  uint8_t xmos_fw_version[5];
   std::string status_string();
-  uint8_t connection_attempts{0};
+
+  Satellite1State get_state() const { return this->state_; }
+  uint8_t get_connection_attempts() const { return this->connection_attempts_; }
+  const uint8_t *get_xmos_fw_version() const { return this->xmos_fw_version_; }
 
   void setup() override;
   void dump_config() override;
@@ -149,7 +150,7 @@ class Satellite1 : public Component,
 
   void set_xmos_rst_pin(GPIOPin *xmos_rst_pin) { this->xmos_rst_pin_ = xmos_rst_pin; }
 
-  void add_on_state_callback(std::function<void()> &&callback) { this->state_callback_.add(std::move(callback)); }
+  template<typename F> void add_on_state_callback(F &&callback) { this->state_callback_.add(std::forward<F>(callback)); }
 
   void xmos_hardware_reset();
 
@@ -157,6 +158,10 @@ class Satellite1 : public Component,
   bool dfu_get_fw_version_();
   bool check_for_xmos_();
   CallbackManager<void()> state_callback_{};
+
+  Satellite1State state_{SAT_DETACHED_STATE};
+  uint8_t xmos_fw_version_[5]{};
+  uint8_t connection_attempts_{0};
 
   uint32_t last_attempt_timestamp_{0};
 


### PR DESCRIPTION
## Summary

- Encapsulate public member variables in `MemoryFlasher` behind getters (`get_state()`, `get_flashing_progress()`, `get_error_code()`, `get_requested_action()`)
- Expose `get_xmos_fw_version()` getter in `satellite1` instead of direct member access
- Rename private `get_active_dac_()` → `get_active_dac_ptr()` in `dac_switcher` (trailing underscore reserved for member variables)
- Replace `void play(Ts... x)` with `void play(const Ts &...)` in action templates
- Add `explicit` to `FlashAction` constructor
- Fix missing `this->` prefixes in `memory_flasher.cpp`
- Fix logic bug in `FlashingProgressUpdateTrigger` where `trigger()` was called outside the `if` block
- Remove inline comments that restate the code