### PR TITLE
dac_switcher: code style cleanup

### DIFF
--- a/components/dac_switcher/audio_dac.py
+++ b/components/dac_switcher/audio_dac.py
@@ -5,7 +5,6 @@ from esphome.components.audio_dac import AudioDac, audio_dac_ns
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@remcom"]
-DEPENDENCIES = []
 
 dac_switcher_ns = cg.esphome_ns.namespace("dac_switcher")
 DacSwitcher = dac_switcher_ns.class_("DacSwitcher", AudioDac, cg.Component)

--- a/components/dac_switcher/automation.h
+++ b/components/dac_switcher/automation.h
@@ -8,12 +8,12 @@ namespace dac_switcher {
 
 template<typename... Ts> class SelectTas2780Action : public Action<Ts...>, public Parented<DacSwitcher> {
  public:
-  void play(Ts... x) override { this->parent_->select_tas2780(); }
+  void play(const Ts &...) override { this->parent_->select_tas2780(); }
 };
 
 template<typename... Ts> class SelectPcm5122Action : public Action<Ts...>, public Parented<DacSwitcher> {
  public:
-  void play(Ts... x) override { this->parent_->select_pcm5122(); }
+  void play(const Ts &...) override { this->parent_->select_pcm5122(); }
 };
 
 }  // namespace dac_switcher

--- a/components/dac_switcher/dac_switcher.cpp
+++ b/components/dac_switcher/dac_switcher.cpp
@@ -30,7 +30,7 @@ void DacSwitcher::dump_config() {
   ESP_LOGCONFIG(TAG, "  Active DAC: %s", this->active_dac_ == DAC_TAS2780 ? "TAS2780" : "PCM5122");
 }
 
-audio_dac::AudioDac *DacSwitcher::get_active_dac_() {
+audio_dac::AudioDac *DacSwitcher::get_active_dac_ptr() {
   if (this->active_dac_ == DAC_TAS2780) {
     return this->tas2780_;
   }
@@ -39,7 +39,7 @@ audio_dac::AudioDac *DacSwitcher::get_active_dac_() {
 
 bool DacSwitcher::set_mute_off() {
   this->is_muted_ = false;
-  auto *dac = this->get_active_dac_();
+  auto *dac = this->get_active_dac_ptr();
   if (dac == nullptr) {
     return false;
   }
@@ -48,7 +48,7 @@ bool DacSwitcher::set_mute_off() {
 
 bool DacSwitcher::set_mute_on() {
   this->is_muted_ = true;
-  auto *dac = this->get_active_dac_();
+  auto *dac = this->get_active_dac_ptr();
   if (dac == nullptr) {
     return false;
   }
@@ -57,7 +57,7 @@ bool DacSwitcher::set_mute_on() {
 
 bool DacSwitcher::set_volume(float volume) {
   this->volume_ = volume;
-  auto *dac = this->get_active_dac_();
+  auto *dac = this->get_active_dac_ptr();
   if (dac == nullptr) {
     return false;
   }
@@ -72,23 +72,19 @@ void DacSwitcher::select_tas2780() {
 
   if (this->active_dac_ == DAC_TAS2780) {
     ESP_LOGD(TAG, "TAS2780 already active");
-    return;  // Already active
+    return;
   }
 
-  // Mute old DAC (PCM5122)
   if (this->pcm5122_ != nullptr) {
     this->pcm5122_->set_mute_on();
     ESP_LOGD(TAG, "Muted PCM5122");
   }
 
-  // Switch to new DAC
   this->active_dac_ = DAC_TAS2780;
   ESP_LOGI(TAG, "Switched to TAS2780");
 
-  // Apply current volume to new DAC
   this->tas2780_->set_volume(this->volume_);
 
-  // Unmute if switcher isn't muted
   if (!this->is_muted_) {
     this->tas2780_->set_mute_off();
   } else {
@@ -104,23 +100,19 @@ void DacSwitcher::select_pcm5122() {
 
   if (this->active_dac_ == DAC_PCM5122) {
     ESP_LOGD(TAG, "PCM5122 already active");
-    return;  // Already active
+    return;
   }
 
-  // Mute old DAC (TAS2780)
   if (this->tas2780_ != nullptr) {
     this->tas2780_->set_mute_on();
     ESP_LOGD(TAG, "Muted TAS2780");
   }
 
-  // Switch to new DAC
   this->active_dac_ = DAC_PCM5122;
   ESP_LOGI(TAG, "Switched to PCM5122");
 
-  // Apply current volume to new DAC
   this->pcm5122_->set_volume(this->volume_);
 
-  // Unmute if switcher isn't muted
   if (!this->is_muted_) {
     this->pcm5122_->set_mute_off();
   } else {

--- a/components/dac_switcher/dac_switcher.h
+++ b/components/dac_switcher/dac_switcher.h
@@ -17,18 +17,15 @@ class DacSwitcher : public audio_dac::AudioDac, public Component {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
-  // AudioDac interface - pure pass-through to active DAC
   bool set_mute_off() override;
   bool set_mute_on() override;
   bool set_volume(float volume) override;
   bool is_muted() override { return this->is_muted_; }
   float volume() override { return this->volume_; }
 
-  // Configuration methods
   void set_tas2780(audio_dac::AudioDac *dac) { this->tas2780_ = dac; }
   void set_pcm5122(audio_dac::AudioDac *dac) { this->pcm5122_ = dac; }
 
-  // Switching methods
   void select_tas2780();
   void select_pcm5122();
 
@@ -37,11 +34,11 @@ class DacSwitcher : public audio_dac::AudioDac, public Component {
  protected:
   audio_dac::AudioDac *tas2780_{nullptr};
   audio_dac::AudioDac *pcm5122_{nullptr};
-  DacSelection active_dac_{DAC_TAS2780};  // Default to TAS2780
+  DacSelection active_dac_{DAC_TAS2780};
   float volume_{0.0f};
   bool is_muted_{false};
 
-  audio_dac::AudioDac *get_active_dac_();
+  audio_dac::AudioDac *get_active_dac_ptr();
 };
 
 }  // namespace dac_switcher


### PR DESCRIPTION
## dac_switcher: code style cleanup

Small cleanup pass on the `dac_switcher` component to align with ESPHome coding conventions.

### Changes

- **`audio_dac.py`**: Remove empty `DEPENDENCIES = []` (implicit default, no need to declare)
- **`automation.h`**: Fix `play()` signature to use `const Ts &...` instead of `Ts... x` (avoids unused parameter warning, matches ESPHome convention)
- **`dac_switcher.cpp` / `dac_switcher.h`**: Rename `get_active_dac_()` → `get_active_dac_ptr()` to avoid the trailing underscore convention being misread as a private member variable
- **`dac_switcher.cpp` / `dac_switcher.h`**: Remove redundant inline comments that restate what the code already clearly expresses

No functional changes.