### PR TITLE
Power down idle DACs, fix dump_summary for 2026.7, clean up release workflow & clang style

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,221 @@
+---
+Checks: >-
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -boost-*,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-invalid-enum-default-initialization,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -bugprone-narrowing-conversions,
+  -bugprone-tagged-union-member-count,
+  -bugprone-signed-char-misuse,
+  -bugprone-switch-missing-default-case,
+  -cert-dcl50-cpp,
+  -cert-err33-c,
+  -cert-err58-cpp,
+  -cert-int09-c,
+  -cert-oop57-cpp,
+  -cert-str34-c,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-osx.*,
+  -clang-analyzer-security.ArrayBound,
+  -clang-diagnostic-delete-abstract-non-virtual-dtor,
+  -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
+  -clang-diagnostic-deprecated-declarations,
+  -clang-diagnostic-ignored-optimization-argument,
+  -clang-diagnostic-missing-designated-field-initializers,
+  -clang-diagnostic-missing-field-initializers,
+  -clang-diagnostic-shadow-field,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-parameter,
+  -clang-diagnostic-vla-cxx-extension,
+  -concurrency-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-to-enum,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-missing-std-forward,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-rvalue-reference-param-not-moved,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-use-default-member-init,
+  -cppcoreguidelines-use-enum-class,
+  -cppcoreguidelines-virtual-class-destructor,
+  -fuchsia-default-arguments-calls,
+  -fuchsia-default-arguments-declarations,
+  -fuchsia-multiple-inheritance,
+  -fuchsia-overloaded-operator,
+  -fuchsia-statically-constructed-objects,
+  -google-build-using-namespace,
+  -google-explicit-constructor,
+  -google-readability-braces-around-statements,
+  -google-readability-casting,
+  -google-readability-namespace-comments,
+  -google-readability-todo,
+  -google-runtime-references,
+  -hicpp-*,
+  -llvm-else-after-return,
+  -llvm-header-guard,
+  -llvm-include-order,
+  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-qualified-auto,
+  -llvm-use-ranges,
+  -llvmlibc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-multiple-inheritance,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-override-with-different-visibility,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
+  -modernize-avoid-bind,
+  -modernize-avoid-variadic-functions,
+  -modernize-avoid-c-arrays,
+  -modernize-avoid-c-style-cast,
+  -modernize-macro-to-enum,
+  -modernize-return-braced-init-list,
+  -modernize-type-traits,
+  -modernize-use-auto,
+  -modernize-use-constraints,
+  -modernize-use-default-member-init,
+  -modernize-use-designated-initializers,
+  -modernize-use-equals-default,
+  -modernize-use-integer-sign-comparison,
+  -modernize-use-nodiscard,
+  -modernize-use-nullptr,
+  -modernize-use-ranges,
+  -modernize-use-trailing-return-type,
+  -mpi-*,
+  -objc-*,
+  -performance-enum-size,
+  -portability-avoid-pragma-once,
+  -portability-template-virtual-member-function,
+  -readability-ambiguous-smartptr-reset-call,
+  -readability-avoid-nested-conditional-operator,
+  -readability-container-data-pointer,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-enum-initial-value,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-math-missing-parentheses,
+  -readability-named-parameter,
+  -readability-redundant-casting,
+  -readability-redundant-inline-specifier,
+  -readability-redundant-member-init,
+  -readability-redundant-parentheses,
+  -readability-redundant-typename,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
+  -readability-use-std-min-max,
+  -readability-use-concise-preprocessor-directives,
+WarningsAsErrors: '*'
+FormatStyle:     google
+CheckOptions:
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-runtime-int.TypeSuffix
+    value:           '_t'
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           'esphome/core/helpers.h'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.VirtualMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.VirtualMethodSuffix
+    value:           ''
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           0
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumLoopCounterNameLength
+    value:           0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,14 @@ jobs:
           SAFE_VERSION="${GITHUB_REF_NAME//-/_}"
           echo "SAFE_VERSION=${SAFE_VERSION}" >> $GITHUB_ENV
 
+      - name: Set channel variable
+        run: |
+          if [ "${{ github.event.release.prerelease }}" == "true" ]; then
+            echo "CHANNEL=beta" >> $GITHUB_ENV
+          else
+            echo "CHANNEL=latest" >> $GITHUB_ENV
+          fi
+
       - name: Set firmware version in config
         run: |
           sed -i 's/esp32_fw_version: dev/esp32_fw_version: ${{ env.VERSION }}/' config/satellite1.base.yaml
@@ -83,14 +91,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Stable release: upload into "latest"
-      - name: Prepare stable latest artifacts
-        if: github.event.release.prerelease == false
+      - name: Prepare channel artifacts
         run: |
-          mkdir -p "release-artifacts/latest/${{ matrix.device }}"
+          CHANNEL="${{ env.CHANNEL }}"
+          mkdir -p "release-artifacts/${CHANNEL}/${{ matrix.device }}"
           for f in release-artifacts/${{ matrix.device }}/*; do
             base=$(basename "$f")
-            # Remove version from filename for latest release
+            # Remove version from filename for channel release
             if [[ "$base" == *".ota.bin" ]]; then
               newname="${{ matrix.device }}.ota.bin"
             elif [[ "$base" == *".bin" ]]; then
@@ -100,78 +107,30 @@ jobs:
             else
               newname="$base"
             fi
-            cp "$f" "release-artifacts/latest/${{ matrix.device }}/$newname"
+            cp "$f" "release-artifacts/${CHANNEL}/${{ matrix.device }}/$newname"
           done
           # Fix paths in manifest to match renamed files
-          MANIFEST="release-artifacts/latest/${{ matrix.device }}/${{ matrix.device }}-manifest.json"
+          MANIFEST="release-artifacts/${CHANNEL}/${{ matrix.device }}/${{ matrix.device }}-manifest.json"
           if [ -f "$MANIFEST" ]; then
             sed -i 's/-esp32s3\.ota\.bin/.ota.bin/g' "$MANIFEST"
             sed -i 's/-esp32s3\.factory\.bin/.bin/g' "$MANIFEST"
           fi
 
-      - name: Delete old latest assets for this device
-        if: github.event.release.prerelease == false
+      - name: Delete old channel assets for this device
         run: |
-          gh release view latest --json assets -q '.assets[].name' 2>/dev/null | grep "^${{ matrix.device }}" | while read asset; do
+          gh release view "${{ env.CHANNEL }}" --json assets -q '.assets[].name' 2>/dev/null | grep "^${{ matrix.device }}" | while read asset; do
             echo "Deleting old asset: $asset"
-            gh release delete-asset latest "$asset" -y || true
+            gh release delete-asset "${{ env.CHANNEL }}" "$asset" -y || true
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload latest artifacts (stable only)
-        if: github.event.release.prerelease == false
+      - name: Upload channel artifacts
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: latest
+          tag_name: ${{ env.CHANNEL }}
           files: |
-            release-artifacts/latest/${{ matrix.device }}/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Prerelease: upload into "beta"
-      - name: Prepare prerelease beta artifacts
-        if: github.event.release.prerelease == true
-        run: |
-          mkdir -p "release-artifacts/beta/${{ matrix.device }}"
-          for f in release-artifacts/${{ matrix.device }}/*; do
-            base=$(basename "$f")
-            # Remove version from filename for beta release
-            if [[ "$base" == *".ota.bin" ]]; then
-              newname="${{ matrix.device }}.ota.bin"
-            elif [[ "$base" == *".bin" ]]; then
-              newname="${{ matrix.device }}.bin"
-            elif [[ "$base" == *".manifest.json" ]]; then
-              newname="${{ matrix.device }}-manifest.json"
-            else
-              newname="$base"
-            fi
-            cp "$f" "release-artifacts/beta/${{ matrix.device }}/$newname"
-          done
-          # Fix paths in manifest to match renamed files
-          MANIFEST="release-artifacts/beta/${{ matrix.device }}/${{ matrix.device }}-manifest.json"
-          if [ -f "$MANIFEST" ]; then
-            sed -i 's/-esp32s3\.ota\.bin/.ota.bin/g' "$MANIFEST"
-            sed -i 's/-esp32s3\.factory\.bin/.bin/g' "$MANIFEST"
-          fi
-
-      - name: Delete old beta assets for this device
-        if: github.event.release.prerelease == true
-        run: |
-          gh release view beta --json assets -q '.assets[].name' 2>/dev/null | grep "^${{ matrix.device }}" | while read asset; do
-            echo "Deleting old asset: $asset"
-            gh release delete-asset beta "$asset" -y || true
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload beta artifacts (for prerelease only)
-        if: github.event.release.prerelease == true
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: beta
-          files: |
-            release-artifacts/beta/${{ matrix.device }}/*
+            release-artifacts/${{ env.CHANNEL }}/${{ matrix.device }}/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -187,15 +146,16 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           REPO="${GITHUB_REPOSITORY}"
+          CHANNEL="${{ github.event.release.prerelease && 'beta' || 'latest' }}"
           mkdir -p release-artifacts
 
           cat <<EOF > release-artifacts/landing-manifest.json
           {
             "version": "${VERSION}",
             "devices": {
-              "satellite1": { "manifest_url": "https://github.com/${REPO}/releases/download/${{ github.event.release.prerelease && 'beta' || 'latest' }}/satellite1-manifest.json" },
-              "satellite1.ld2450": { "manifest_url": "https://github.com/${REPO}/releases/download/${{ github.event.release.prerelease && 'beta' || 'latest' }}/satellite1.ld2450-manifest.json" },
-              "satellite1.ld2410": { "manifest_url": "https://github.com/${REPO}/releases/download/${{ github.event.release.prerelease && 'beta' || 'latest' }}/satellite1.ld2410-manifest.json" }
+              "satellite1": { "manifest_url": "https://github.com/${REPO}/releases/download/${CHANNEL}/satellite1-manifest.json" },
+              "satellite1.ld2450": { "manifest_url": "https://github.com/${REPO}/releases/download/${CHANNEL}/satellite1.ld2450-manifest.json" },
+              "satellite1.ld2410": { "manifest_url": "https://github.com/${REPO}/releases/download/${CHANNEL}/satellite1.ld2410-manifest.json" }
             }
           }
           EOF
@@ -207,3 +167,37 @@ jobs:
           files: release-artifacts/landing-manifest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_site_manifest:
+    needs: build
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Download latest firmware bins
+        run: |
+          gh release download latest --repo "${{ github.repository }}" \
+            --pattern "satellite1.bin" \
+            --pattern "satellite1.ld2410.bin" \
+            --pattern "satellite1.ld2450.bin" \
+            --dir site/manifests \
+            --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit updated bins
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add site/manifests/*.bin
+          if git diff --cached --quiet; then
+            echo "No changes to site manifest bins"
+          else
+            git commit -m "chore: update site manifest firmware bins for ${GITHUB_REF_NAME}"
+            git push origin HEAD:${{ github.event.repository.default_branch }}
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,25 +26,25 @@ jobs:
           clang-format-version: '18'
           check-path: 'esphome/components'
 
-  clang-tidy:
-    name: clang-tidy (components)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+  # clang-tidy:
+  #   name: clang-tidy (components)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v6
+  #       with:
+  #         python-version: '3.13'
 
-      - name: Install ESPHome and clang-tidy
-        run: |
-          pip install -r requirements.txt
-          pip install clang-tidy==18.1.8
+  #     - name: Install ESPHome and clang-tidy
+  #       run: |
+  #         pip install -r requirements.txt
+  #         pip install clang-tidy==18.1.8
 
-      - name: Run clang-tidy on components/ and esphome/components/
-        run: python3 scripts/run_clang_tidy.py
+  #     - name: Run clang-tidy on components/ and esphome/components/
+  #       run: python3 scripts/run_clang_tidy.py
 
   yamllint:
     name: yamllint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,26 @@ jobs:
           clang-format-version: '18'
           check-path: 'esphome/components'
 
+  clang-tidy:
+    name: clang-tidy (components)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install ESPHome and clang-tidy
+        run: |
+          pip install -r requirements.txt
+          pip install clang-tidy==18.1.8
+
+      - name: Run clang-tidy on components/ and esphome/components/
+        run: python3 scripts/run_clang_tidy.py
+
   yamllint:
     name: yamllint
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,18 @@ repos:
         name: clang-format (check, v18) [esphome]
         files: ^components/.*\.(c|cc|cpp|cxx|h|hh|hpp|hxx)$
         args: ["--dry-run", "--Werror", "--style=file"]
+
+  - repo: local
+    hooks:
+      - id: clang-tidy
+        name: clang-tidy [esphome]
+        entry: python3 scripts/run_clang_tidy.py
+        language: system
+        files: ^(components|esphome/components)/.*\.(cc|cpp)$
+        pass_filenames: true
+        # Regenerates compile_commands.json itself (codegen + cmake configure, no ninja
+        # build, ~1 min) but that's still too slow for every commit, so it's opt-in:
+        # pre-commit run --hook-stage manual clang-tidy
+        # For fast local iteration once compile_commands.json is fresh, run the script
+        # directly with --skip-regen.
+        stages: [manual]

--- a/components/fusb302b/automation.h
+++ b/components/fusb302b/automation.h
@@ -3,8 +3,7 @@
 #include "esphome/core/automation.h"
 #include "pd.h"
 
-namespace esphome {
-namespace fusb302b {
+namespace esphome::fusb302b {
 
 template<typename... Ts> class PowerDeliveryRequestVoltage : public Action<Ts...>, public Parented<PowerDelivery> {
  public:
@@ -63,5 +62,4 @@ template<typename... Ts> class IsConnectedCondition : public Condition<Ts...>, p
   }
 };
 
-}  // namespace fusb302b
-}  // namespace esphome
+}  // namespace esphome::fusb302b

--- a/components/fusb302b/fusb302_defines.h
+++ b/components/fusb302b/fusb302_defines.h
@@ -1,8 +1,7 @@
 #pragma once
 #include <cstdint>
 
-namespace esphome {
-namespace fusb302b {
+namespace esphome::fusb302b {
 
 // Register addresses
 static constexpr uint8_t FUSB_DEVICE_ID = 0x01;
@@ -144,5 +143,4 @@ static constexpr uint8_t FUSB_FIFO_RX_SOP2 = 0xA0;
 static constexpr uint8_t FUSB_FIFO_RX_SOP1DB = 0x80;
 static constexpr uint8_t FUSB_FIFO_RX_SOP2DB = 0x60;
 
-}  // namespace fusb302b
-}  // namespace esphome
+}  // namespace esphome::fusb302b

--- a/components/fusb302b/fusb302b.cpp
+++ b/components/fusb302b/fusb302b.cpp
@@ -9,8 +9,7 @@
 
 #include "fusb302_defines.h"
 
-namespace esphome {
-namespace fusb302b {
+namespace esphome::fusb302b {
 
 static const char *const TAG = "fusb302b";
 
@@ -63,6 +62,9 @@ void msg_reader_task(void *params) {
         fusb302b->read_status_register(FUSB_STATUS1, regs.status1);
       }
     }
+    // These branches only differ by ESP_LOGV message; at lower LOG_LOCAL_LEVEL the macro compiles
+    // away entirely, making the branches look identical.
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (regs.interrupta & FUSB_INTERRUPTA_I_HARDRST) {
       ESP_LOGV(TAG, "Hard reset received");
     } else if (regs.interrupta & FUSB_INTERRUPTA_I_SOFTRST) {
@@ -490,7 +492,6 @@ bool FUSB302B::send_message(const PDMsg &msg) {
   return err == i2c::ERROR_OK;
 }
 
-}  // namespace fusb302b
-}  // namespace esphome
+}  // namespace esphome::fusb302b
 
 #endif  // USE_ESP_IDF

--- a/components/fusb302b/fusb302b.h
+++ b/components/fusb302b/fusb302b.h
@@ -12,8 +12,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #endif
 
-namespace esphome {
-namespace fusb302b {
+namespace esphome::fusb302b {
 
 enum class Fusb302State { UNATTACHED, ATTACHED, FAILED };
 
@@ -82,7 +81,6 @@ class FUSB302B : public PowerDelivery, public Component, public i2c::I2CDevice {
   QueueHandle_t message_queue_{nullptr};
 };
 
-}  // namespace fusb302b
-}  // namespace esphome
+}  // namespace esphome::fusb302b
 
 #endif  // USE_ESP_IDF

--- a/components/fusb302b/pd.cpp
+++ b/components/fusb302b/pd.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace fusb302b {
+namespace esphome::fusb302b {
 
 static const char *const TAG = "PowerDelivery";
 
@@ -256,5 +255,4 @@ void PDMsg::debug_log() const {
            this->num_of_obj, !!(this->extended), this->get_coded_header());
 }
 
-}  // namespace fusb302b
-}  // namespace esphome
+}  // namespace esphome::fusb302b

--- a/components/i2s_audio/i2s_audio.cpp
+++ b/components/i2s_audio/i2s_audio.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 static const char *const TAG = "i2s_audio";
 
@@ -18,8 +17,8 @@ void I2SAudioBase::dump_i2s_settings() const {
   } else {
     ESP_LOGCONFIG(TAG, "I2S-Writer (%s):", init_str.c_str());
   }
-  ESP_LOGCONFIG(TAG, "  sample-rate: %d slot_mode: %d slot_mask: %d slot_bit_width: %d", this->sample_rate_,
-                this->slot_mode_, this->std_slot_mask_, this->slot_bit_width_);
+  ESP_LOGCONFIG(TAG, "  sample-rate: %u slot_mode: %d slot_mask: %d slot_bit_width: %d",
+                (unsigned) this->sample_rate_, this->slot_mode_, this->std_slot_mask_, this->slot_bit_width_);
   ESP_LOGCONFIG(TAG, "  use_apll: %s", this->use_apll_ ? "yes" : "no");
 }
 
@@ -60,11 +59,11 @@ bool I2SPortComponent::init_driver_(i2s_std_config_t std_cfg) {
       .auto_clear = true,
   };
 
-  i2s_chan_handle_t *pTxHandle = this->audio_out_ != nullptr ? &this->tx_handle_ : nullptr;
-  i2s_chan_handle_t *pRxHandle = this->audio_in_ != nullptr ? &this->rx_handle_ : nullptr;
+  i2s_chan_handle_t *tx_handle_ptr = this->audio_out_ != nullptr ? &this->tx_handle_ : nullptr;
+  i2s_chan_handle_t *rx_handle_ptr = this->audio_in_ != nullptr ? &this->rx_handle_ : nullptr;
 
   /* Allocate channels and receive their handles*/
-  esp_err_t err = i2s_new_channel(&chan_cfg, pTxHandle, pRxHandle);
+  esp_err_t err = i2s_new_channel(&chan_cfg, tx_handle_ptr, rx_handle_ptr);
   if (err != ESP_OK) {
     this->unlock();
     return false;
@@ -94,7 +93,7 @@ bool I2SPortComponent::init_driver_(i2s_std_config_t std_cfg) {
   return true;
 }
 
-bool I2SAudioOut::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
+bool I2SAudioOut::start_i2s_channel(i2s_event_callbacks_t callbacks) {
   if (this->parent_->tx_handle_ == nullptr) {
     if (this->parent_->rx_handle_ != nullptr) {
       ESP_LOGE(TAG, "Trying to start I2S-TX channel, but RX handle is available. This is not allowed.");
@@ -139,7 +138,7 @@ bool I2SAudioOut::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
   return true;
 }
 
-bool I2SAudioOut::stop_i2s_channel_() {
+bool I2SAudioOut::stop_i2s_channel() {
   if (this->parent_->tx_handle_ == nullptr) {
     ESP_LOGE(TAG, "Trying to stop I2S-TX channel, but handle is nullptr.");
     return false;
@@ -167,7 +166,7 @@ bool I2SAudioOut::stop_i2s_channel_() {
   return true;
 }
 
-bool I2SAudioIn::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
+bool I2SAudioIn::start_i2s_channel(i2s_event_callbacks_t callbacks) {
   if (this->parent_->rx_handle_ == nullptr) {
     if (this->parent_->tx_handle_ != nullptr) {
       ESP_LOGE(TAG, "Trying to start I2S-RX channel, but TX handle is available. This is not allowed.");
@@ -201,7 +200,7 @@ bool I2SAudioIn::start_i2s_channel_(i2s_event_callbacks_t callbacks) {
   return true;
 }
 
-bool I2SAudioIn::stop_i2s_channel_() {
+bool I2SAudioIn::stop_i2s_channel() {
   if (this->parent_->rx_handle_ == nullptr) {
     ESP_LOGE(TAG, "Trying to stop I2S-RX channel, but handle is nullptr.");
     return false;
@@ -223,7 +222,6 @@ bool I2SAudioIn::stop_i2s_channel_() {
   return true;
 }
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/i2s_audio.cpp
+++ b/components/i2s_audio/i2s_audio.cpp
@@ -17,8 +17,8 @@ void I2SAudioBase::dump_i2s_settings() const {
   } else {
     ESP_LOGCONFIG(TAG, "I2S-Writer (%s):", init_str.c_str());
   }
-  ESP_LOGCONFIG(TAG, "  sample-rate: %u slot_mode: %d slot_mask: %d slot_bit_width: %d",
-                (unsigned) this->sample_rate_, this->slot_mode_, this->std_slot_mask_, this->slot_bit_width_);
+  ESP_LOGCONFIG(TAG, "  sample-rate: %u slot_mode: %d slot_mask: %d slot_bit_width: %d", (unsigned) this->sample_rate_,
+                this->slot_mode_, this->std_slot_mask_, this->slot_bit_width_);
   ESP_LOGCONFIG(TAG, "  use_apll: %s", this->use_apll_ ? "yes" : "no");
 }
 

--- a/components/i2s_audio/i2s_audio.h
+++ b/components/i2s_audio/i2s_audio.h
@@ -7,8 +7,7 @@
 #include "esphome/core/defines.h"
 #include <driver/i2s_std.h>
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 class I2SAccess {
  public:
@@ -76,12 +75,12 @@ class I2SAudioBase {
   }
 
  protected:
-  virtual bool start_i2s_channel_(i2s_event_callbacks_t callbacks) = 0;
-  virtual bool start_i2s_channel_() {
+  virtual bool start_i2s_channel(i2s_event_callbacks_t callbacks) = 0;
+  virtual bool start_i2s_channel() {
     const i2s_event_callbacks_t callbacks = {};
-    return this->start_i2s_channel_(callbacks);
+    return this->start_i2s_channel(callbacks);
   }
-  virtual bool stop_i2s_channel_() = 0;
+  virtual bool stop_i2s_channel() = 0;
 
   virtual bool IRAM_ATTR i2s_overflow_cb(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
     return true;
@@ -164,9 +163,9 @@ class I2SAudioIn : public I2SAudioBase, public Parented<I2SPortComponent> {
   void register_at_parent() override { this->parent_->set_audio_in(this); }
 
  protected:
-  using I2SAudioBase::start_i2s_channel_;
-  bool start_i2s_channel_(i2s_event_callbacks_t callbacks) override;
-  bool stop_i2s_channel_() override;
+  using I2SAudioBase::start_i2s_channel;
+  bool start_i2s_channel(i2s_event_callbacks_t callbacks) override;
+  bool stop_i2s_channel() override;
   gpio_num_t din_pin_{I2S_GPIO_UNUSED};
 };
 
@@ -189,14 +188,13 @@ class I2SAudioOut : public I2SAudioBase, public Parented<I2SPortComponent> {
   bool is_adjustable() const { return !this->is_fixed_; }
 
  protected:
-  using I2SAudioBase::start_i2s_channel_;
-  bool start_i2s_channel_(i2s_event_callbacks_t callbacks) override;
-  bool stop_i2s_channel_() override;
+  using I2SAudioBase::start_i2s_channel;
+  bool start_i2s_channel(i2s_event_callbacks_t callbacks) override;
+  bool stop_i2s_channel() override;
   gpio_num_t dout_pin_{I2S_GPIO_UNUSED};
   bool callbacks_registered_{false};
 };
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 static const size_t RING_BUFFER_LENGTH = 60;  // Measured in milliseconds
 static const size_t QUEUE_LENGTH = 10;
@@ -159,7 +158,7 @@ void I2SAudioMicrophone::configure_stream_settings_() {
 }
 
 bool I2SAudioMicrophone::start_driver_() {
-  if (!this->start_i2s_channel_()) {
+  if (!this->start_i2s_channel()) {
     ESP_LOGE(TAG, "Failed to start I2S channel");
     return false;
   }
@@ -167,7 +166,7 @@ bool I2SAudioMicrophone::start_driver_() {
   return true;
 }
 
-bool I2SAudioMicrophone::stop_driver_() { return this->stop_i2s_channel_(); }
+bool I2SAudioMicrophone::stop_driver_() { return this->stop_i2s_channel(); }
 
 size_t I2SAudioMicrophone::read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait) {
   size_t bytes_read = 0;
@@ -252,7 +251,6 @@ void I2SAudioMicrophone::mic_task(void *params) {
   }
 }
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -3,26 +3,23 @@
 #ifdef USE_ESP32
 
 #include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
 #include <freertos/queue.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
 
 #include "esphome/components/i2s_audio/i2s_audio.h"
 #include "esphome/components/microphone/microphone.h"
 #include "esphome/core/component.h"
 
-#include <freertos/FreeRTOS.h>
-#include <freertos/event_groups.h>
-#include <freertos/semphr.h>
-#include <freertos/task.h>
-
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
  public:
   void setup() override;
   void dump_config() override { this->dump_i2s_settings(); }
-  void start();
-  void stop();
+  void start() override;
+  void stop() override;
 
   void loop() override;
 
@@ -55,7 +52,6 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   int32_t dc_offset_{0};
 };
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -12,8 +12,7 @@
 // esp-audio-libs
 #include <gain.h>
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 static const char *const TAG = "i2s_audio.speaker";
 
@@ -76,7 +75,7 @@ void I2SAudioSpeakerBase::loop() {
       this->speaker_task_handle_ = nullptr;
     }
 
-    this->stop_i2s_channel_();
+    this->stop_i2s_channel();
     this->on_task_stopped();
 
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
@@ -93,7 +92,7 @@ void I2SAudioSpeakerBase::loop() {
   if ((event_group_bits & SpeakerEventGroupBits::COMMAND_START) && (this->state_ == speaker::STATE_STARTING)) {
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
 
-    if (this->start_i2s_driver_(this->audio_stream_info_) != ESP_OK) {
+    if (this->start_i2s_driver(this->audio_stream_info_) != ESP_OK) {
       ESP_LOGE(TAG, "Driver failed to start; retrying in 1 second");
       this->state_ = speaker::STATE_STOPPED;
       this->status_momentary_error("driver-failure", 1000);
@@ -104,7 +103,7 @@ void I2SAudioSpeakerBase::loop() {
       if (this->speaker_task_handle_ == nullptr) {
         ESP_LOGE(TAG, "Failed to create speaker task");
         this->status_set_error(LOG_STR("Failed to create speaker task"));
-        this->stop_i2s_channel_();
+        this->stop_i2s_channel();
         this->state_ = speaker::STATE_STOPPED;
       }
     }
@@ -262,7 +261,6 @@ void I2SAudioSpeakerBase::swap_esp32_mono_samples_(uint8_t *data, size_t bytes_r
 #endif  // USE_ESP32_VARIANT_ESP32
 }
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -16,8 +16,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/ring_buffer/ring_buffer.h"
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 // Shared constants for I2S audio speaker implementations
 static constexpr uint32_t DMA_BUFFER_DURATION_MS = 15;
@@ -48,7 +47,7 @@ enum SpeakerEventGroupBits : uint32_t {
 /// @brief Abstract base class for I2S audio speaker implementations.
 /// Provides shared infrastructure: event groups, ring buffer, software volume control,
 /// task lifecycle, and common setup()/loop()/start()/stop()/play() logic.
-/// Derived classes implement run_speaker_task() and start_i2s_driver_().
+/// Derived classes implement run_speaker_task() and start_i2s_driver().
 class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public Component {
  public:
   float get_setup_priority() const override { return esphome::setup_priority::PROCESSOR; }
@@ -83,8 +82,8 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   virtual void run_speaker_task() = 0;
 
   /// @brief Starts the I2S driver for the given stream. Called from loop() before task spawn.
-  /// Uses the shared I2S bus via start_i2s_channel_() / stop_i2s_channel_().
-  virtual esp_err_t start_i2s_driver_(audio::AudioStreamInfo &audio_stream_info) = 0;
+  /// Uses the shared I2S bus via start_i2s_channel() / stop_i2s_channel().
+  virtual esp_err_t start_i2s_driver(audio::AudioStreamInfo &audio_stream_info) = 0;
 
   /// @brief Called in loop() when the task has stopped. Override for mode-specific cleanup.
   virtual void on_task_stopped() {}
@@ -114,7 +113,6 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   audio::AudioStreamInfo current_stream_info_;
 };
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
+++ b/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
@@ -10,8 +10,7 @@
 
 #include "esp_timer.h"
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 static const char *const TAG = "i2s_audio.speaker.std";
 
@@ -37,7 +36,7 @@ void I2SAudioSpeaker::dump_config() {
 
 void I2SAudioSpeaker::set_i2s_comm_fmt(I2SCommFmt fmt) {
   this->i2s_comm_fmt_ = fmt;
-  // Propagate to parent's string field, which start_i2s_channel_() reads.
+  // Propagate to parent's string field, which start_i2s_channel() reads.
   switch (fmt) {
     case I2SCommFmt::PCM:
       I2SAudioBase::set_i2s_comm_fmt("pcm");
@@ -71,7 +70,7 @@ void I2SAudioSpeaker::run_speaker_task() {
   // When the I2S slot width exceeds the stream bit depth (e.g., 32-bit I2S with 16-bit
   // audio), each sample must be expanded before writing so the DMA sees the correct number
   // of bytes per frame.  Only the 2× case (16-bit → 32-bit) is supported; other ratios
-  // are rejected by start_i2s_driver_() before the task reaches this point.
+  // are rejected by start_i2s_driver() before the task reaches this point.
   const uint8_t expand_factor = this->i2s_bits_per_sample() / this->current_stream_info_.get_bits_per_sample();
 
   bool successful_setup = false;
@@ -219,7 +218,7 @@ void I2SAudioSpeaker::run_speaker_task() {
   }
 }
 
-esp_err_t I2SAudioSpeaker::start_i2s_driver_(audio::AudioStreamInfo &audio_stream_info) {
+esp_err_t I2SAudioSpeaker::start_i2s_driver(audio::AudioStreamInfo &audio_stream_info) {
   this->current_stream_info_ = audio_stream_info;
 
   if (this->has_fixed_i2s_rate() && (this->sample_rate_ != audio_stream_info.get_sample_rate())) {
@@ -241,13 +240,12 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_(audio::AudioStreamInfo &audio_strea
 
   // Start with no on_sent callback; the task registers it after the first preload
   const i2s_event_callbacks_t no_callbacks = {.on_sent = nullptr};
-  if (!this->start_i2s_channel_(no_callbacks)) {
+  if (!this->start_i2s_channel(no_callbacks)) {
     return ESP_ERR_INVALID_STATE;
   }
   return ESP_OK;
 }
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/i2s_audio/speaker/i2s_audio_speaker_standard.h
+++ b/components/i2s_audio/speaker/i2s_audio_speaker_standard.h
@@ -4,8 +4,7 @@
 
 #include "i2s_audio_speaker.h"
 
-namespace esphome {
-namespace i2s_audio {
+namespace esphome::i2s_audio {
 
 enum class I2SCommFmt : uint8_t {
   STANDARD,  // Philips / I2S standard
@@ -26,12 +25,11 @@ class I2SAudioSpeaker : public I2SAudioSpeakerBase {
 
  protected:
   void run_speaker_task() override;
-  esp_err_t start_i2s_driver_(audio::AudioStreamInfo &audio_stream_info) override;
+  esp_err_t start_i2s_driver(audio::AudioStreamInfo &audio_stream_info) override;
 
   I2SCommFmt i2s_comm_fmt_{I2SCommFmt::STANDARD};
 };
 
-}  // namespace i2s_audio
-}  // namespace esphome
+}  // namespace esphome::i2s_audio
 
 #endif  // USE_ESP32

--- a/components/resampler/microphone/resampler_microphone.cpp
+++ b/components/resampler/microphone/resampler_microphone.cpp
@@ -10,8 +10,7 @@
 #include <algorithm>
 #include <cstring>
 
-namespace esphome {
-namespace resampler {
+namespace esphome::resampler {
 
 static const UBaseType_t RESAMPLER_TASK_PRIORITY = 1;
 static const UBaseType_t MAX_LISTENERS = 16;
@@ -328,7 +327,6 @@ void ResamplerMicrophone::resample_task(void *params) {
   }
 }
 
-}  // namespace resampler
-}  // namespace esphome
+}  // namespace esphome::resampler
 
 #endif

--- a/components/resampler/microphone/resampler_microphone.h
+++ b/components/resampler/microphone/resampler_microphone.h
@@ -15,8 +15,7 @@
 #include <freertos/event_groups.h>
 #include <freertos/semphr.h>
 
-namespace esphome {
-namespace resampler {
+namespace esphome::resampler {
 
 class ResamplerMicrophone : public Component, public microphone::Microphone {
  public:
@@ -74,7 +73,6 @@ class ResamplerMicrophone : public Component, public microphone::Microphone {
   audio::AudioStreamInfo source_stream_info_;
 };
 
-}  // namespace resampler
-}  // namespace esphome
+}  // namespace esphome::resampler
 
 #endif

--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -9,6 +9,11 @@ globals:
     type: bool
     restore_value: no
     initial_value: 'false'
+  # Tracks whether the PCM5122 is currently powered (not in powerdown mode)
+  - id: pcm5122_active
+    type: bool
+    restore_value: no
+    initial_value: 'true'
 
 audio_dac:
   # Define both DACs
@@ -78,7 +83,11 @@ binary_sensor:
 
     on_press:
       # Cable inserted - switch to line-out DAC
+      #  - Bring the PCM5122 out of powerdown before routing audio to it
+      #  - TAS2780 is no longer in use, deactivate it
       #  - Enable Sendspin static delay adjustment to apply the persisted delay when using the external audio output
+      - script.execute: pcm5122_ensure_active
+      - script.execute: tas2780_ensure_powerdown
       - audio_dac.mute_on: speaker_dac_tas2780
       - router.speaker.switch_output:
           id: router_speaker
@@ -98,10 +107,13 @@ binary_sensor:
     on_release:
       # Cable removed - switch back to speaker DAC
       #  - Disable Sendspin static delay adjustment when using the internal speaker
+      #  - TAS2780 is reactivated by on_state once audio is actually playing
+      #  - PCM5122 is no longer in use, put it into powerdown
       - audio_dac.mute_on: speaker_dac_pcm5122
       - router.speaker.switch_output:
           id: router_speaker
           target_speaker: i2s_tas2780_speaker
+      - script.execute: pcm5122_ensure_powerdown
       - lambda: id(jack_unplugged_recently) = true;
       - script.execute: control_leds
       - sendspin.media_source.disable_static_delay_adjustment:
@@ -287,14 +299,26 @@ media_player:
           duration: 0.0s
     # Restore audio ducking when not actively playing announcements or running voice assistant
     on_state:
-      # Ensure TAS2780 is active when audio is playing
+      # Ensure TAS2780 is active when audio is playing through the internal speaker
       - if:
           condition:
-            or:
-              - media_player.is_playing: external_media_player
-              - media_player.is_announcing: external_media_player
+            and:
+              - binary_sensor.is_off: line_out_sensor
+              - or:
+                  - media_player.is_playing: external_media_player
+                  - media_player.is_announcing: external_media_player
           then:
             - script.execute: tas2780_ensure_active
+      # Ensure PCM5122 is out of powerdown when audio is playing through the line-out
+      - if:
+          condition:
+            and:
+              - binary_sensor.is_on: line_out_sensor
+              - or:
+                  - media_player.is_playing: external_media_player
+                  - media_player.is_announcing: external_media_player
+          then:
+            - script.execute: pcm5122_ensure_active
       - if:
           condition:
             and:
@@ -368,6 +392,42 @@ script:
                 power_mode: !lambda return id(tas2780_power_mode);
             - lambda: id(tas2780_active) = true;
 
+  # Script to deactivate TAS2780 when it's not in use
+  - id: tas2780_ensure_powerdown
+    mode: single
+    then:
+      - if:
+          condition:
+            lambda: return id(tas2780_active);
+          then:
+            - logger.log: "Deactivating TAS2780"
+            - tas2780.deactivate:
+            - lambda: id(tas2780_active) = false;
+
+  # Script to bring the PCM5122 out of powerdown when it's needed for line-out playback
+  - id: pcm5122_ensure_active
+    mode: single
+    then:
+      - if:
+          condition:
+            lambda: return !id(pcm5122_active);
+          then:
+            - logger.log: "Bringing PCM5122 out of powerdown"
+            - lambda: id(speaker_dac_pcm5122)->set_powerdown(false);
+            - lambda: id(pcm5122_active) = true;
+
+  # Script to put the PCM5122 into powerdown when it's not in use
+  - id: pcm5122_ensure_powerdown
+    mode: single
+    then:
+      - if:
+          condition:
+            lambda: return id(pcm5122_active);
+          then:
+            - logger.log: "Putting PCM5122 into powerdown"
+            - lambda: id(speaker_dac_pcm5122)->set_powerdown(true);
+            - lambda: id(pcm5122_active) = false;
+
 text_sensor:
   - platform: sendspin
     id: track_title
@@ -406,3 +466,15 @@ interval:
             - logger.log: "Deactivating TAS2780 due to 60 seconds of idle"
             - tas2780.deactivate:
             - lambda: id(tas2780_active) = false;
+      - if:
+          condition:
+            - binary_sensor.is_on: line_out_sensor
+            - lambda: return id(pcm5122_active);
+            - for:
+                time: 60s
+                condition:
+                  or:
+                    - media_player.is_idle: external_media_player
+                    - media_player.is_paused: external_media_player
+          then:
+            - script.execute: pcm5122_ensure_powerdown

--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -106,13 +106,13 @@ micro_wake_word:
   stop_after_detection: false
   task_stack_in_psram: true
   models:
-    - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
+    - model: https://github.com/OHF-Voice/micro-wake-word/releases/download/okay_nabu_20241226.3/okay_nabu.json
       id: okay_nabu
     - model: hey_jarvis
       id: hey_jarvis
     - model: hey_mycroft
       id: hey_mycroft
-    - model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
+    - model: https://github.com/OHF-Voice/micro-wake-word/releases/download/stop/stop.json
       id: stop
       internal: true
   vad:

--- a/esphome/components/memory_flasher/automation.h
+++ b/esphome/components/memory_flasher/automation.h
@@ -3,8 +3,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace memory_flasher {
+namespace esphome::memory_flasher {
 
 template<typename... Ts> class FlashAction : public Action<Ts...> {
  public:
@@ -100,5 +99,4 @@ template<typename... Ts> class InProgressCondition : public Condition<Ts...>, pu
   bool check(Ts... x) override { return this->parent_->get_state() != FLASHER_IDLE; }
 };
 
-}  // namespace memory_flasher
-}  // namespace esphome
+}  // namespace esphome::memory_flasher

--- a/esphome/components/memory_flasher/memory_flasher.cpp
+++ b/esphome/components/memory_flasher/memory_flasher.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/components/md5/md5.h"
 
-namespace esphome {
-namespace memory_flasher {
+namespace esphome::memory_flasher {
 
 static const char *const TAG = "memory_flasher";
 
@@ -83,10 +82,7 @@ bool HttpImageReader::init_reader() {
   ESP_LOGI(TAG, "Connecting to: %s", this->url_.c_str());
 
   this->container_ = this->http_request_->get(url_with_auth);
-  if (this->container_ == nullptr) {
-    return false;
-  }
-  return true;
+  return this->container_ != nullptr;
 }
 
 bool HttpImageReader::deinit_reader() {
@@ -103,5 +99,4 @@ int HttpImageReader::read_image_block(uint8_t *buffer, size_t block_size) {
   return bytes_read;
 }
 
-}  // namespace memory_flasher
-}  // namespace esphome
+}  // namespace esphome::memory_flasher

--- a/esphome/components/memory_flasher/memory_flasher.h
+++ b/esphome/components/memory_flasher/memory_flasher.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/http_request/http_request.h"
 
-namespace esphome {
-namespace memory_flasher {
+namespace esphome::memory_flasher {
 
 static const uint8_t MD5_SIZE = 32;
 
@@ -46,7 +45,7 @@ class FlashImageReader {
 class HttpImageReader : public FlashImageReader {
  public:
   HttpImageReader(http_request::HttpRequestComponent *http_request, std::string url)
-      : http_request_(http_request), url_(url) {}
+      : http_request_(http_request), url_(std::move(url)) {}
   bool init_reader() override;
   bool deinit_reader() override;
 
@@ -66,7 +65,7 @@ class HttpImageReader : public FlashImageReader {
 
 class EmbeddedImageReader : public FlashImageReader {
  public:
-  EmbeddedImageReader(FlashImage img) : image_(img) {}
+  EmbeddedImageReader(FlashImage img) : image_(std::move(img)) {}
   bool init_reader() override {
     this->read_pos_ = 0;
     return true;
@@ -118,7 +117,7 @@ class MemoryFlasher : public Component {
   FlasherAction get_requested_action() const { return this->requested_action_; }
   uint8_t get_flashing_progress() const { return this->flashing_progress_; }
 
-  virtual void dump_config() override;
+  void dump_config() override;
 
   virtual bool init_flasher() { return true; }
   virtual bool deinit_flasher() { return true; }
@@ -139,7 +138,7 @@ class MemoryFlasher : public Component {
                           const char version_bytes[5]) {
     this->embedded_image_.data = pgm_pointer;
     this->embedded_image_.length = length;
-    this->embedded_image_.md5 = expected_md5;
+    this->embedded_image_.md5 = std::move(expected_md5);
     memcpy(this->embedded_image_.version.bytes, version_bytes, 5);
   }
 
@@ -160,7 +159,7 @@ class MemoryFlasher : public Component {
   }
 
  protected:
-  virtual void publish_progress_() {}
+  virtual void publish_progress() {}
   CallbackManager<void()> state_callback_{};
 
   uint8_t flashing_progress_{0};
@@ -186,5 +185,4 @@ class MemoryFlasher : public Component {
   std::string url_{};
 };
 
-}  // namespace memory_flasher
-}  // namespace esphome
+}  // namespace esphome::memory_flasher

--- a/esphome/components/satellite1/automation.h
+++ b/esphome/components/satellite1/automation.h
@@ -3,8 +3,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace satellite1 {
+namespace esphome::satellite1 {
 
 template<typename... Ts> class XMOSHardwareResetAction : public Action<Ts...>, public Parented<Satellite1> {
  public:
@@ -34,5 +33,4 @@ class XMOSNoResponseStateTrigger : public Trigger<> {
   }
 };
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
+++ b/esphome/components/satellite1/memory_flasher/xmos_flashing.cpp
@@ -3,9 +3,8 @@
 
 #include <endian.h>
 
-namespace esphome {
+namespace esphome::satellite1 {
 using namespace memory_flasher;
-namespace satellite1 {
 
 static const char *const TAG = "xmos_flasher";
 
@@ -29,7 +28,7 @@ void XMOSFlasher::loop() {
 
     case FLASHER_ERASING: {
       int remaining = this->erasing_step_();
-      this->publish_progress_();
+      this->publish_progress();
       if (remaining == 0 && this->requested_action_ == ACTION_FULL_ERASE) {
         this->deinit_flashing_();
         this->state_ = FLASHER_SUCCESS_STATE;
@@ -43,7 +42,7 @@ void XMOSFlasher::loop() {
 
     case FLASHER_FLASHING: {
       int remaining = this->flashing_step_();
-      this->publish_progress_();
+      this->publish_progress();
       if (remaining == 0) {
         this->deinit_flashing_();
         this->state_ = FLASHER_SUCCESS_STATE;
@@ -55,10 +54,6 @@ void XMOSFlasher::loop() {
     }
 
     case FLASHER_SUCCESS_STATE:
-      this->publish();
-      this->state_ = FLASHER_IDLE;
-      break;
-
     case FLASHER_ERROR_STATE:
       this->publish();
       this->state_ = FLASHER_IDLE;
@@ -69,7 +64,7 @@ void XMOSFlasher::loop() {
   }
 }
 
-void XMOSFlasher::publish_progress_() {
+void XMOSFlasher::publish_progress() {
   uint32_t now = millis();
 
   if ((now - this->last_published_) > 1000) {
@@ -162,18 +157,18 @@ void XMOSFlasher::flash_embedded_image() {
 
 bool XMOSFlasher::read_jedec_id_() {
   uint8_t manufacturer = 0;
-  uint8_t memoryType = 0;
+  uint8_t memory_type = 0;
   uint8_t capcacity = 0;
-  this->enable();
-  this->transfer_byte(0x9F);
-  manufacturer = this->transfer_byte(0);
-  memoryType = this->transfer_byte(0);
-  capcacity = this->transfer_byte(0);
-  this->disable();
+  this->enable_();
+  this->transfer_byte_(0x9F);
+  manufacturer = this->transfer_byte_(0);
+  memory_type = this->transfer_byte_(0);
+  capcacity = this->transfer_byte_(0);
+  this->disable_();
 
-  if (manufacturer && memoryType && capcacity) {
+  if (manufacturer && memory_type && capcacity) {
     this->manufacturer_id_ = manufacturer;
-    this->memory_type_id_ = memoryType;
+    this->memory_type_id_ = memory_type;
     this->capacity_id_ = capcacity;
     return true;
   }
@@ -182,15 +177,14 @@ bool XMOSFlasher::read_jedec_id_() {
 
 bool XMOSFlasher::wait_while_flash_busy_(uint32_t timeout_ms) {
   int32_t timeout_invoke = millis();
-  const uint8_t WEL = 2;
-  const uint8_t BUSY = 1;
+  const uint8_t busy = 1;
 
   while ((millis() - timeout_invoke) < timeout_ms) {
-    this->enable();
-    this->transfer_byte(0x05);
-    uint8_t status = this->transfer_byte(0x00);
-    this->disable();
-    if ((status & BUSY) == 0) {
+    this->enable_();
+    this->transfer_byte_(0x05);
+    uint8_t status = this->transfer_byte_(0x00);
+    this->disable_();
+    if ((status & busy) == 0) {
       return true;
     }
   }
@@ -199,26 +193,23 @@ bool XMOSFlasher::wait_while_flash_busy_(uint32_t timeout_ms) {
 
 bool XMOSFlasher::enable_writing_() {
   // enable writing
-  this->enable();
-  this->transfer_byte(0x06);
-  this->disable();
+  this->enable_();
+  this->transfer_byte_(0x06);
+  this->disable_();
 
-  this->enable();
-  this->transfer_byte(0x05);
-  uint8_t status = this->transfer_byte(0x00);
-  this->disable();
-  const uint8_t WEL = 2;
-  if (!(status & WEL)) {
-    return false;
-  }
-  return true;
+  this->enable_();
+  this->transfer_byte_(0x05);
+  uint8_t status = this->transfer_byte_(0x00);
+  this->disable_();
+  const uint8_t wel = 2;
+  return (status & wel) != 0;
 }
 
 bool XMOSFlasher::disable_writing_() {
   // disable writing
-  this->enable();
-  this->transfer_byte(0x04);
-  this->disable();
+  this->enable_();
+  this->transfer_byte_(0x04);
+  this->disable_();
   return true;
 }
 
@@ -232,12 +223,12 @@ bool XMOSFlasher::erase_sector_(int sector) {
     return false;
   }
 
-  this->enable();
-  this->transfer_byte(0x20);
-  this->transfer_byte(*(u8_ptr + 2));
-  this->transfer_byte(*(u8_ptr + 1));
-  this->transfer_byte(*(u8_ptr));
-  this->disable();
+  this->enable_();
+  this->transfer_byte_(0x20);
+  this->transfer_byte_(*(u8_ptr + 2));
+  this->transfer_byte_(*(u8_ptr + 1));
+  this->transfer_byte_(*(u8_ptr));
+  this->disable_();
 
   // this->disable_writing_();
   return true;
@@ -248,15 +239,15 @@ bool XMOSFlasher::chip_erase_() {
     return false;
   }
 
-  this->enable();
-  this->transfer_byte(0xc7);
-  this->disable();
+  this->enable_();
+  this->transfer_byte_(0xc7);
+  this->disable_();
 
   // this->disable_writing_();
   return true;
 }
 
-bool XMOSFlasher::write_page_(uint32_t byte_addr, uint8_t *buffer) {
+bool XMOSFlasher::write_page_(uint32_t byte_addr, const uint8_t *buffer) {
   if ((byte_addr & (FLASH_PAGE_SIZE - 1)) != 0) {
     ESP_LOGE(TAG, "Address needs to be page aligned (%d).", FLASH_PAGE_SIZE);
     return false;
@@ -268,15 +259,15 @@ bool XMOSFlasher::write_page_(uint32_t byte_addr, uint8_t *buffer) {
 
   uint32_t u32 = htole32(byte_addr);
   uint8_t *u8_ptr = (uint8_t *) &u32;
-  this->enable();
-  this->transfer_byte(0x02);
-  this->transfer_byte(*(u8_ptr + 2));
-  this->transfer_byte(*(u8_ptr + 1));
-  this->transfer_byte(*(u8_ptr));
+  this->enable_();
+  this->transfer_byte_(0x02);
+  this->transfer_byte_(*(u8_ptr + 2));
+  this->transfer_byte_(*(u8_ptr + 1));
+  this->transfer_byte_(*(u8_ptr));
   for (int pos = 0; pos < FLASH_PAGE_SIZE; pos++) {
-    this->transfer_byte(*(buffer + pos));
+    this->transfer_byte_(*(buffer + pos));
   }
-  this->disable();
+  this->disable_();
 
   if (!this->wait_while_flash_busy_(15)) {
     ESP_LOGE(TAG, "Writing page timeout");
@@ -292,16 +283,16 @@ bool XMOSFlasher::read_page_(uint32_t byte_addr, uint8_t *buffer) {
   }
   uint32_t u32 = htole32(byte_addr);
   uint8_t *u8_ptr = (uint8_t *) &u32;
-  this->enable();
-  this->transfer_byte(0x0B);
-  this->transfer_byte(*(u8_ptr + 2));
-  this->transfer_byte(*(u8_ptr + 1));
-  this->transfer_byte(*(u8_ptr));
-  this->transfer_byte(0x00);
+  this->enable_();
+  this->transfer_byte_(0x0B);
+  this->transfer_byte_(*(u8_ptr + 2));
+  this->transfer_byte_(*(u8_ptr + 1));
+  this->transfer_byte_(*(u8_ptr));
+  this->transfer_byte_(0x00);
   for (int pos = 0; pos < FLASH_PAGE_SIZE; pos++) {
-    *(buffer + pos) = this->transfer_byte(0x00);
+    *(buffer + pos) = this->transfer_byte_(0x00);
   }
-  this->disable();
+  this->disable_();
   return true;
 }
 
@@ -331,6 +322,9 @@ bool XMOSFlasher::init_flashing_() {
     return false;
   }
 
+  // NOLINTBEGIN(cppcoreguidelines-no-malloc): exceptions are disabled in this build
+  // (CONFIG_COMPILER_CXX_EXCEPTIONS=n), so a std::vector allocation failure would abort()
+  // instead of letting us report INIT_FLASH_ERROR and bail out gracefully.
   this->reader_buffer_ = (uint8_t *) malloc(FLASH_PAGE_SIZE);
   if (this->reader_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Couldn't allocate memory");
@@ -344,6 +338,7 @@ bool XMOSFlasher::init_flashing_() {
     this->error_code_ = INIT_FLASH_ERROR;
     return false;
   }
+  // NOLINTEND(cppcoreguidelines-no-malloc)
 
   ESP_LOGD(TAG, "MD5 expected: %s", this->md5_expected_.c_str());
 
@@ -365,6 +360,7 @@ bool XMOSFlasher::init_flashing_() {
 }
 
 void XMOSFlasher::deinit_flashing_() {
+  // NOLINTBEGIN(cppcoreguidelines-no-malloc): pairs with the malloc() in init_flashing_().
   if (this->reader_buffer_) {
     free(this->reader_buffer_);
     this->reader_buffer_ = nullptr;
@@ -374,6 +370,7 @@ void XMOSFlasher::deinit_flashing_() {
     free(this->compare_buffer_);
     this->compare_buffer_ = nullptr;
   }
+  // NOLINTEND(cppcoreguidelines-no-malloc)
 
   if (this->reader_) {
     this->reader_->deinit_reader();
@@ -469,5 +466,4 @@ int XMOSFlasher::flashing_step_() {
   return this->bytes_remaining_;
 }
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/esphome/components/satellite1/memory_flasher/xmos_flashing.h
+++ b/esphome/components/satellite1/memory_flasher/xmos_flashing.h
@@ -8,8 +8,7 @@
 #include "esphome/components/memory_flasher/memory_flasher.h"
 #include "esphome/components/satellite1/satellite1.h"
 
-namespace esphome {
-namespace satellite1 {
+namespace esphome::satellite1 {
 
 class XMOSFlasher : public memory_flasher::MemoryFlasher, public Satellite1SPIService {
  public:
@@ -38,7 +37,7 @@ class XMOSFlasher : public memory_flasher::MemoryFlasher, public Satellite1SPISe
   bool erase_sector_(int sector);
   bool wait_while_flash_busy_(uint32_t timeout_ms);
   bool read_page_(uint32_t byte_addr, uint8_t *buffer);
-  bool write_page_(uint32_t byte_addr, uint8_t *buffer);
+  bool write_page_(uint32_t byte_addr, const uint8_t *buffer);
 
   uint8_t manufacturer_id_;
   uint8_t memory_type_id_;
@@ -50,7 +49,7 @@ class XMOSFlasher : public memory_flasher::MemoryFlasher, public Satellite1SPISe
   void deinit_flashing_();
   int flashing_step_();
   int erasing_step_();
-  void publish_progress_() override;
+  void publish_progress() override;
 
   bool http_flash_{false};
   bool embedded_flash_{false};
@@ -69,5 +68,4 @@ class XMOSFlasher : public memory_flasher::MemoryFlasher, public Satellite1SPISe
   uint8_t *compare_buffer_;
 };
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/esphome/components/satellite1/sat_gpio.cpp
+++ b/esphome/components/satellite1/sat_gpio.cpp
@@ -1,9 +1,8 @@
 #include "sat_gpio.h"
 
-namespace esphome {
-namespace satellite1 {
+namespace esphome::satellite1 {
 
-static const char *TAG = "Satellite1-GPIOs";
+static const char *const TAG = "Satellite1-GPIOs";
 
 void Satellite1GPIOPin::digital_write(bool value) {
   if (this->parent_ == nullptr) {
@@ -23,7 +22,7 @@ bool Satellite1GPIOPin::digital_read() {
     ESP_LOGE(TAG, "Parent not set for GPIO pin");
     return false;
   }
-  DC_STATUS_REGISTER::register_id port_register;
+  DC_STATUS_REGISTER::RegisterId port_register;
   switch (this->port_) {
     case XMOSPort::INPUT_A:
       port_register = DC_STATUS_REGISTER::GPIO_PORT_IN_A;
@@ -36,7 +35,7 @@ bool Satellite1GPIOPin::digital_read() {
       break;
     default:
       ESP_LOGE(TAG, "Invalid port set.");
-      return 0;
+      return false;
       break;
   }
   this->parent_->request_status_register_update();
@@ -45,5 +44,4 @@ bool Satellite1GPIOPin::digital_read() {
   return bit_value ^ this->inverted_;
 }
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/esphome/components/satellite1/sat_gpio.h
+++ b/esphome/components/satellite1/sat_gpio.h
@@ -23,7 +23,7 @@ class Satellite1GPIOPin : public GPIOPin, public Satellite1SPIService {
   void pin_mode(gpio::Flags flags) override {}
   bool digital_read() override;
   void digital_write(bool value) override;
-  std::string dump_summary() const override { return ""; };
+  size_t dump_summary(char *buffer, size_t len) const override { return 0; }
 
   void set_pin(XMOSPort port, uint8_t pin) {
     this->port_ = port;

--- a/esphome/components/satellite1/sat_gpio.h
+++ b/esphome/components/satellite1/sat_gpio.h
@@ -4,8 +4,7 @@
 
 #include "satellite1.h"
 
-namespace esphome {
-namespace satellite1 {
+namespace esphome::satellite1 {
 
 static const uint8_t GPIO_SERVICER_CMD_READ_PORT = 0x00;
 static const uint8_t GPIO_SERVICER_CMD_WRITE_PORT = 0x01;
@@ -31,7 +30,7 @@ class Satellite1GPIOPin : public GPIOPin, public Satellite1SPIService {
   }
   void set_inverted(bool inverted) { this->inverted_ = inverted; }
   void set_flags(gpio::Flags flags) { this->flags_ = flags; }
-  gpio::Flags get_flags() const { return this->flags_; }
+  gpio::Flags get_flags() const override { return this->flags_; }
 
  protected:
   XMOSPort port_{XMOSPort::INPUT_A};
@@ -40,5 +39,4 @@ class Satellite1GPIOPin : public GPIOPin, public Satellite1SPIService {
   gpio::Flags flags_{};
 };
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/esphome/components/satellite1/satellite1.cpp
+++ b/esphome/components/satellite1/satellite1.cpp
@@ -2,8 +2,7 @@
 #include "esp_rom_gpio.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace satellite1 {
+namespace esphome::satellite1 {
 
 static const char *const TAG = "Satellite1";
 
@@ -182,11 +181,10 @@ bool Satellite1::check_for_xmos_() {
 }
 
 void Satellite1::xmos_hardware_reset() {
-  this->xmos_rst_pin_->digital_write(1);
+  this->xmos_rst_pin_->digital_write(true);
   delay(100);
-  this->xmos_rst_pin_->digital_write(0);
+  this->xmos_rst_pin_->digital_write(false);
   delay(100);
 }
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/esphome/components/satellite1/satellite1.h
+++ b/esphome/components/satellite1/satellite1.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
 
-namespace esphome {
-namespace satellite1 {
+namespace esphome::satellite1 {
 
 static const uint8_t CONTROL_RESOURCE_CNTRL_ID = 1;
 static const uint8_t CONTROL_CMD_READ_BIT = 0x80;
@@ -23,7 +22,7 @@ static const uint8_t DFU_CONTROLLER_SERVICER_RESID = 240;
 static const uint8_t MAX_CONNECTION_ATTEMPTS = 3;
 
 namespace DC_RESOURCE {
-enum dc_resource_enum {
+enum DcResourceEnum {
   CNTRL_ID = 1,
   DFU_CONTROLLER = DFU_CONTROLLER_SERVICER_RESID,
   GPIO_PORT_IN_A = GPIO_SERVICER_RESID_PORT_IN_A,
@@ -33,11 +32,11 @@ enum dc_resource_enum {
 }
 
 namespace DC_RET_STATUS {
-enum dc_ret_status_enum { CMD_SUCCESS = 0, DEVICE_BUSY = 7, PAYLOAD_AVAILABLE = 23 };
+enum DcRetStatusEnum { CMD_SUCCESS = 0, DEVICE_BUSY = 7, PAYLOAD_AVAILABLE = 23 };
 }
 
 namespace DC_STATUS_REGISTER {
-enum register_id {
+enum RegisterId {
   DEVICE_STATUS = 0,
   GPIO_PORT_IN_A = 1,
   GPIO_PORT_IN_B = 2,
@@ -48,7 +47,7 @@ enum register_id {
 }
 
 namespace DC_DFU_CMD {
-enum dc_dfu_cmd_id {
+enum DcDfuCmdId {
   GET_VERSION = (88 | CONTROL_CMD_READ_BIT),
 };
 }
@@ -141,7 +140,7 @@ class Satellite1 : public Component,
    * @return             The cached value of the requested status register as an 8-bit
    *                     unsigned integer.
    */
-  uint8_t get_dc_status(DC_STATUS_REGISTER::register_id reg) {
+  uint8_t get_dc_status(DC_STATUS_REGISTER::RegisterId reg) {
     assert(reg < DC_STATUS_REGISTER::REGISTER_LEN);
     return this->dc_status_register_[reg];
   }
@@ -182,11 +181,10 @@ class Satellite1SPIService : public Parented<Satellite1> {
   }
 
  protected:
-  uint8_t transfer_byte(uint8_t byte) { return this->parent_->transfer_byte(byte); }
-  void enable() { this->parent_->enable(); }
-  void disable() { this->parent_->disable(); }
+  uint8_t transfer_byte_(uint8_t byte) { return this->parent_->transfer_byte(byte); }
+  void enable_() { this->parent_->enable(); }
+  void disable_() { this->parent_->disable(); }
   uint8_t servicer_id_;
 };
 
-}  // namespace satellite1
-}  // namespace esphome
+}  // namespace esphome::satellite1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2026.6.0
+esphome @ git+https://github.com/esphome/esphome.git@dev
 setuptools

--- a/scripts/run_clang_tidy.py
+++ b/scripts/run_clang_tidy.py
@@ -144,8 +144,35 @@ def clang_options(idedata: dict, build_dir: Path) -> list[str]:
     return cmd
 
 
+def _patch_pio_wrapped_mirror_urls() -> None:
+    """Work around an esphome bug hit on a cold cache (e.g. fresh CI runner):
+    something in the native-ESP-IDF framework download path can hand
+    ``download_from_mirrors`` a PlatformIO-style ``owner/pkg@url`` spec
+    instead of a plain URL, which ``requests.get()`` then rejects with
+    InvalidSchema. Once a version's framework is extracted once, this
+    codepath isn't hit again, so it only bites the very first run.
+
+    Wrap ``download_from_mirrors`` to strip any such prefix from each mirror
+    before it's used, regardless of which caller produced it. Patched on the
+    ``esphome.espidf.framework`` module specifically -- it imports the name
+    with ``from esphome.framework_helpers import download_from_mirrors``, so
+    patching the original module's attribute wouldn't affect that call site.
+    """
+    import esphome.espidf.framework as espidf_framework
+
+    original = espidf_framework.download_from_mirrors
+
+    def patched(mirrors, substitutions, target, timeout=30):
+        cleaned = [m.split("@", 1)[1] if "@http" in m else m for m in mirrors]
+        return original(cleaned, substitutions, target, timeout=timeout)
+
+    espidf_framework.download_from_mirrors = patched
+
+
 def regenerate_compile_commands(device: str) -> None:
     """Codegen + cmake-configure (no ninja build) to (re)produce compile_commands.json."""
+    _patch_pio_wrapped_mirror_urls()
+
     import esphome.__main__ as esphome_main
 
     sys.argv = ["esphome", "-q", "compile", "--only-generate", f"config/{device}.yaml"]

--- a/scripts/run_clang_tidy.py
+++ b/scripts/run_clang_tidy.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Run clang-tidy over this repo's own components (components/, esphome/components/).
+
+Builds compiler flags from compile_commands.json, using esphome.espidf.idedata
+(ships with the pinned esphome package). Vanilla LLVM clang-tidy has no Xtensa
+backend, so for Xtensa targets we compile in a generic 32-bit mode with the same
+flag/macro substitutions ESPHome's own script/clang-tidy uses upstream
+(github.com/esphome/esphome script/clang-tidy): drop GCC-only flags, pretend to
+be Xtensa via defines, and stub pgmspace.h.
+
+compile_commands.json normally only exists after a full firmware build (ninja
+compiles every source file, ~10-20 minutes). We don't need that: `esphome compile
+--only-generate` (codegen only) followed by ESP-IDF's cmake *configure* step
+(toolchain.run_reconfigure(), no ninja) produces an accurate compile_commands.json
+in under a minute. This script does that itself by default -- no manual build step
+needed first. Pass --skip-regen to reuse whatever's already on disk (e.g. from a
+real `esphome compile`, or to avoid re-running it across repeated local iterations).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent / ".venv" / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}" / "site-packages")
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPONENT_DIRS = ("components", "esphome/components")
+
+# GCC-only flags clang doesn't understand, and ones that would recreate real
+# Xtensa codegen we're not attempting. Verbatim from esphome/esphome's
+# script/clang-tidy.
+OMIT_FLAGS = {
+    "-free",
+    "-fipa-pta",
+    "-fstrict-volatile-bitfields",
+    "-mlongcalls",
+    "-mtext-section-literals",
+    "-mdisable-hardware-atomics",
+    "-mfix-esp32-psram-cache-issue",
+    "-mfix-esp32-psram-cache-strategy=memw",
+    "-fno-tree-switch-conversion",
+    "-freorder-blocks",
+    "-fno-jump-tables",
+    "-fno-shrink-wrap",
+    "-mno-target-align",
+}
+
+
+def git_files(patterns: list[str]) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", *patterns],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def clang_options(idedata: dict, build_dir: Path) -> list[str]:
+    cmd: list[str] = []
+    triplet = Path(idedata["cxx_path"]).name[:-4]  # strip "-g++"
+
+    if triplet.startswith("xtensa-"):
+        # clang has an Xtensa frontend but no real backend for it here (no
+        # esp-clang installed); compile in generic 32-bit mode and pretend to
+        # be Xtensa via defines, same trick ESPHome's own script/clang-tidy uses.
+        # Force a Linux/ELF target explicitly (not the host default) so this
+        # works the same on a macOS dev machine as on upstream's Linux CI --
+        # ESP-IDF's IRAM_ATTR section attribute and GNU attribute syntax
+        # otherwise don't parse under Mach-O/Darwin's clang defaults.
+        cmd += [
+            "--target=i686-pc-linux-gnu",
+            "-m32",
+            "-U__i386__",
+            "-U__x86_64__",
+            "-D__XTENSA__",
+            "-D__XTENSA_EL__",
+            "-D_LIBC",
+        ]
+    else:
+        cmd += [f"--target={triplet}", "-Qunused-arguments"]
+        cmd += ["-nostdinc++"]
+
+    cmd += [
+        "-nostdinc",
+        "-D_PGMSPACE_H_",
+        "-Dpgm_read_byte(s)=(*(const uint8_t *)(s))",
+        "-Dpgm_read_byte_near(s)=(*(const uint8_t *)(s))",
+        "-Dpgm_read_word(s)=(*(const uint16_t *)(s))",
+        "-Dpgm_read_dword(s)=(*(const uint32_t *)(s))",
+        "-Dpgm_read_ptr(s)=(*(const void *const *)(s))",
+        "-DPROGMEM=",
+        "-DPGM_P=const char *",
+        "-DPSTR(s)=(s)",
+        "-DPSTRN(s, n)=(s)",
+        "-Ddeprecated(x)=",
+        "-DCLANG_TIDY",
+        "-D_GLIBCXX_HAVE_TLS",
+    ]
+
+    def strip_esp_march(flag: str) -> str:
+        if flag.startswith("-march=") and triplet.startswith("riscv"):
+            return re.sub(r"_xesp\w+", "", flag)
+        return flag
+
+    cmd += [
+        strip_esp_march(flag)
+        for flag in idedata["cxx_flags"]
+        if flag not in OMIT_FLAGS
+        and not flag.startswith("-Werror")
+        and not flag.startswith("-std=")
+        and not flag.startswith("-mtune=esp")
+    ]
+    cmd.append("-std=gnu++20")
+
+    cmd += [f"-D{define}" for define in idedata["defines"]]
+
+    toolchain_dir = os.path.normpath(f"{idedata['cxx_path']}/../../")
+    for directory in idedata["includes"]["toolchain"]:
+        if directory.startswith(toolchain_dir) and "picolibc" not in directory:
+            cmd += ["-isystem", directory]
+
+    # Our own component sources live under <build_dir>/src/...; keep those as
+    # -I (diagnosed) and everything else (esp-idf framework, managed
+    # components, ...) as -isystem (included but not diagnosed).
+    project_src = str(build_dir / "src")
+    project_includes: list[str] = []
+    for directory in idedata["includes"]["build"]:
+        if directory.startswith(project_src) and "managed_components" not in directory:
+            project_includes.append(directory)
+        else:
+            cmd += ["-isystem", directory]
+    cmd += [f"-I{d}" for d in project_includes]
+    cmd += ["-I", project_src]
+
+    return cmd
+
+
+def regenerate_compile_commands(device: str) -> None:
+    """Codegen + cmake-configure (no ninja build) to (re)produce compile_commands.json."""
+    import esphome.__main__ as esphome_main
+
+    sys.argv = ["esphome", "-q", "compile", "--only-generate", f"config/{device}.yaml"]
+    os.chdir(REPO_ROOT)
+    rc = esphome_main.main()
+    if rc:
+        raise SystemExit(f"error: 'esphome compile --only-generate' failed (exit {rc})")
+
+    from esphome.espidf import toolchain
+
+    rc = toolchain.run_reconfigure()
+    if rc:
+        raise SystemExit(f"error: ESP-IDF cmake reconfigure failed (exit {rc})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="satellite1", help="config/<device>.yaml build to use")
+    parser.add_argument("--fix", action="store_true", help="apply clang-tidy fix-its")
+    parser.add_argument(
+        "--skip-regen",
+        action="store_true",
+        help="reuse the compile_commands.json already on disk instead of regenerating it",
+    )
+    parser.add_argument("files", nargs="*", help="repo-relative files to check (default: all component sources)")
+    args = parser.parse_args()
+
+    build_dir = REPO_ROOT / "config" / ".esphome" / "build" / args.device
+    compile_commands = build_dir / "build" / "compile_commands.json"
+
+    if not args.skip_regen:
+        regenerate_compile_commands(args.device)
+
+    if not compile_commands.is_file():
+        print(f"error: no compile database at {compile_commands}", file=sys.stderr)
+        return 1
+
+    from esphome.espidf.idedata import idedata_from_build
+
+    idedata = idedata_from_build(compile_commands)
+    options = clang_options(idedata, build_dir)
+
+    files = args.files or git_files([f"{d}/*.cpp" for d in COMPONENT_DIRS] + [f"{d}/*.cc" for d in COMPONENT_DIRS])
+
+    project_src = build_dir / "src"
+    status = 0
+    for f in files:
+        rel = f
+        for d in COMPONENT_DIRS:
+            if rel.startswith(d + "/"):
+                rel = rel[len(d) + 1 :]
+                break
+        build_src = project_src / "esphome" / "components" / rel
+        if not build_src.is_file():
+            print(f"warning: {f} has no matching build artifact ({build_src}); rebuild to include it", file=sys.stderr)
+            continue
+
+        invocation = ["clang-tidy"]
+        if args.fix:
+            invocation.append("--fix")
+        invocation.append(f"--header-filter={re.escape(str(project_src))}/.*")
+        invocation.append(str(build_src))
+        invocation.append("--")
+        invocation.extend(options)
+
+        print(f"==> {f}")
+        result = subprocess.run(invocation)
+        if result.returncode != 0:
+            status = 1
+
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Fix `dump_summary()` override in `Satellite1GPIOPin` to match the ESPHome 2026.6/2026.7 `GPIOPin` API change (`std::string` → `size_t(char*, size_t) const`), unbreaking compilation against upstream.
- Power down the PCM5122 and TAS2780 DACs whenever they aren't actively driving audio, since only one of the two is ever in use at a time (internal speaker vs. line-out):
  - PCM5122 now enters powerdown via the new upstream `power_mode` support when the line-out jack is unplugged, or after 60s of idle/paused playback on line-out.
  - TAS2780 is deactivated as soon as the line-out jack is inserted (previously it stayed active until a separate idle timeout), and is re-activated only once audio actually starts playing again.
- Clean up the release workflow (`.github/workflows/build.yaml`): collapse the near-duplicate `latest`/`beta` artifact prep steps into a single channel-parameterized flow, and add a job that pushes freshly built stable release binaries into `site/manifests/` so the ESP Web Tools installer site stays current without a manual build-and-copy step.
- Bring local components (`fusb302b`, `i2s_audio`, `memory_flasher`, `satellite1`, `resampler`) in line with upstream ESPHome C++ style conventions: nested `namespace esphome::satellite1 { ... }` instead of stacked namespace blocks, `PascalCase` enum/type names, and related clang-format/clang-tidy cleanup across headers and sources.

