### PR TITLE
feat(voice): enable noise suppression + auto-gain for cleaner STT input

### DIFF
--- a/config/common/voice_assistant.yaml
+++ b/config/common/voice_assistant.yaml
@@ -168,8 +168,11 @@ voice_assistant:
   media_player: external_media_player
   micro_wake_word: mww
   use_wake_word: false
-  noise_suppression_level: 0
-  auto_gain: 0 dbfs
+  # Enhanced STT input quality: RNNoise suppression + auto-gain lift the
+  # voice above room noise so the (local faster-whisper) STT lane hears a
+  # clean signal. Tunable: suppression 0-4, auto_gain in dBFS.
+  noise_suppression_level: 2
+  auto_gain: 10 dbfs
   volume_multiplier: 1
   on_client_connected:
     - lambda: id(init_in_progress) = false;


### PR DESCRIPTION
Enable ESPHome voice-assistant RNNoise noise suppression (level 2) and auto-gain (10 dBFS) on the Satellite1 voice input. This lifts the voice above room noise so the local STT lane (e.g. faster-whisper) receives a clean signal, materially improving transcription accuracy in real rooms. Tunable: suppression 0-4, auto_gain in dBFS.