### PR TITLE
Fix audio lifecycle races and bump ESPHome

### DIFF
--- a/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -78,9 +78,18 @@ void I2SAudioSpeakerBase::loop() {
     this->stop_i2s_channel();
     this->on_task_stopped();
 
-    xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
+    // ALL_BITS includes COMMAND_START. Take the bits from the clear itself, not from the snapshot at
+    // the top of loop(): the audio source's task can raise a start at any point above, including
+    // during stop_i2s_channel(), and nothing would ever re-issue it.
+    const EventBits_t bits_before_clear = xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
     this->status_clear_error();
-    this->state_ = speaker::STATE_STOPPED;
+    if (bits_before_clear & SpeakerEventGroupBits::COMMAND_START) {
+      ESP_LOGD(TAG, "Start requested while stopping; keeping the request");
+      xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
+      this->state_ = speaker::STATE_STARTING;
+    } else {
+      this->state_ = speaker::STATE_STOPPED;
+    }
   }
 
   if (event_group_bits & SpeakerEventGroupBits::ERR_ESP_NO_MEM) {
@@ -89,14 +98,17 @@ void I2SAudioSpeakerBase::loop() {
   }
 
   // Spawn task when COMMAND_START is received and speaker is starting
-  if ((event_group_bits & SpeakerEventGroupBits::COMMAND_START) && (this->state_ == speaker::STATE_STARTING)) {
+  // The task handle is only cleared once TASK_STOPPED has been processed above; starting the driver
+  // while a previous run is still winding down fails spuriously, so keep the request pending instead.
+  if ((event_group_bits & SpeakerEventGroupBits::COMMAND_START) && (this->state_ == speaker::STATE_STARTING) &&
+      (this->speaker_task_handle_ == nullptr)) {
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
 
     if (this->start_i2s_driver(this->audio_stream_info_) != ESP_OK) {
       ESP_LOGE(TAG, "Driver failed to start; retrying in 1 second");
       this->state_ = speaker::STATE_STOPPED;
       this->status_momentary_error("driver-failure", 1000);
-    } else if (this->speaker_task_handle_ == nullptr) {
+    } else {
       xTaskCreate(I2SAudioSpeakerBase::speaker_task, "speaker_task", TASK_STACK_SIZE, (void *) this, TASK_PRIORITY,
                   &this->speaker_task_handle_);
 
@@ -171,8 +183,8 @@ size_t I2SAudioSpeakerBase::play(const uint8_t *data, size_t length, TickType_t 
 }
 
 bool I2SAudioSpeakerBase::has_buffered_data() const {
-  if (this->audio_ring_buffer_.use_count() > 0) {
-    std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->audio_ring_buffer_.lock();
+  std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->audio_ring_buffer_.lock();
+  if (temp_ring_buffer != nullptr) {
     return temp_ring_buffer->available() > 0;
   }
   return false;

--- a/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
+++ b/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
@@ -83,7 +83,7 @@ void I2SAudioSpeaker::run_speaker_task() {
 
   if (transfer_buffer != nullptr && (expand_factor == 1 || expansion_buffer != nullptr)) {
     std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = ring_buffer::RingBuffer::create(ring_buffer_size);
-    if (temp_ring_buffer.use_count() == 1) {
+    if (temp_ring_buffer != nullptr) {
       transfer_buffer->set_source(temp_ring_buffer);
       this->audio_ring_buffer_ = temp_ring_buffer;  // assign to base weak_ptr
       successful_setup = true;

--- a/components/resampler/microphone/resampler_microphone.cpp
+++ b/components/resampler/microphone/resampler_microphone.cpp
@@ -55,7 +55,7 @@ void ResamplerMicrophone::setup() {
     }
     if (this->requires_resampling_()) {
       std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->ring_buffer_.lock();
-      if (this->ring_buffer_.use_count() > 1) {
+      if (temp_ring_buffer != nullptr) {
         size_t bytes_free = temp_ring_buffer->free();
 
         if (bytes_free < data.size()) {
@@ -253,7 +253,7 @@ void ResamplerMicrophone::resample_task(void *params) {
     std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer =
         ring_buffer::RingBuffer::create(source_stream_info.ms_to_bytes(this_resampler->buffer_duration_ms_));
 
-    if (temp_ring_buffer.use_count() == 0) {
+    if (temp_ring_buffer == nullptr) {
       err = ESP_ERR_NO_MEM;
     } else {
       this_resampler->ring_buffer_ = temp_ring_buffer;
@@ -262,7 +262,7 @@ void ResamplerMicrophone::resample_task(void *params) {
       // Create output ring buffer for resampled audio
       output_ring_buffer = ring_buffer::RingBuffer::create(
           this_resampler->audio_stream_info_.ms_to_bytes(this_resampler->buffer_duration_ms_));
-      if (output_ring_buffer.use_count() == 0) {
+      if (output_ring_buffer == nullptr) {
         err = ESP_ERR_NO_MEM;
       } else {
         std::weak_ptr<ring_buffer::RingBuffer> output_ring_buffer_weak = output_ring_buffer;

--- a/components/resampler/speaker/resampler_speaker.cpp
+++ b/components/resampler/speaker/resampler_speaker.cpp
@@ -153,8 +153,8 @@ void ResamplerSpeaker::loop() {
     ESP_LOGV(TAG, "Stopping");
     xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::STATE_STOPPING);
   }
-  if (event_group_bits & ResamplingEventGroupBits::STATE_STOPPED) {
-    this->task_.deallocate();
+  // Retries on a subsequent loop if the task is still running on the other core
+  if ((event_group_bits & ResamplingEventGroupBits::STATE_STOPPED) && this->task_.deallocate()) {
     ESP_LOGD(TAG, "Stopped");
     xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ALL_BITS);
   }
@@ -235,7 +235,7 @@ size_t ResamplerSpeaker::play(const uint8_t *data, size_t length, TickType_t tic
     bytes_written = this->output_speaker_->play(data, length, ticks_to_wait);
   } else {
     std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->ring_buffer_.lock();
-    if (temp_ring_buffer) {
+    if (temp_ring_buffer != nullptr) {
       // Only write to the ring buffer if the reference is valid
       bytes_written = temp_ring_buffer->write_without_replacement(data, length, ticks_to_wait);
     } else {
@@ -299,7 +299,7 @@ bool ResamplerSpeaker::has_buffered_data() const {
   bool has_ring_buffer_data = false;
   if (this->requires_resampling_()) {
     std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->ring_buffer_.lock();
-    if (temp_ring_buffer) {
+    if (temp_ring_buffer != nullptr) {
       has_ring_buffer_data = (temp_ring_buffer->available() > 0);
     }
   }
@@ -342,7 +342,7 @@ void ResamplerSpeaker::resample_task(void *params) {
       std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = ring_buffer::RingBuffer::create(
           this_resampler->audio_stream_info_.ms_to_bytes(this_resampler->buffer_duration_ms_));
 
-      if (!temp_ring_buffer) {
+      if (temp_ring_buffer == nullptr) {
         err = ESP_ERR_NO_MEM;
       } else {
         this_resampler->ring_buffer_ = temp_ring_buffer;

--- a/config/common/media_player.yaml
+++ b/config/common/media_player.yaml
@@ -267,6 +267,12 @@ media_source:
     buffer_size: 500000
   - platform: sendspin
     id: sendspin_media_source
+    # Preference order (2026.9). Set explicitly: the ESPHome default list is emitted as raw
+    # strings instead of codec enums and fails to compile (upstream 2026.9.0b3 regression).
+    codecs:
+      - flac  # least processor intensive
+      - opus  # 48 kHz only
+      - pcm
 
 media_player:
   - platform: sendspin

--- a/config/satellite1.base.yaml
+++ b/config/satellite1.base.yaml
@@ -36,7 +36,7 @@ esphome:
   name: ${node_name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2026.8.0
+  min_version: 2026.9.0b3
 
   project:
     name: ${company_name}.${project_name}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2026.9.0b2
+esphome==2026.9.0b3
 setuptools


### PR DESCRIPTION
- Preserve I2S start requests during shutdown and wait for the previous task to stop before restarting.
- Retry resampler task cleanup until deallocation succeeds.
- Check ring buffer pointers directly instead of reference counts.
- Set Sendspin codec preferences explicitly to work around the default codec compilation regression.
- Update ESPHome dependency and minimum version to 2026.9.0b3.